### PR TITLE
Update type URI in attestation

### DIFF
--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -28,7 +28,7 @@ const (
 	// statements].
 	//
 	// [in-toto statements]: https://github.com/in-toto/attestation/blob/main/spec/README.md#statement
-	TypeURI = "text/vex"
+	TypeURI = "https://openvex.dev/ns"
 
 	// DefaultAuthor is the default value for a document's Author field.
 	DefaultAuthor = "Unknown Author"


### PR DESCRIPTION
This commmit modifies the predicate type field in the attestations to use the context URI, correcting it from the mimetype which is currently used (wrong).

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>