### PR TITLE
Drop signed data bufffer

### DIFF
--- a/pkg/attestation/attestation.go
+++ b/pkg/attestation/attestation.go
@@ -18,9 +18,7 @@ import (
 type Attestation struct {
 	intoto.StatementHeader
 	// Predicate contains type specific metadata.
-	Predicate  vex.VEX `json:"predicate"`
-	Signed     bool    `json:"-"`
-	signedData []byte  `json:"-"`
+	Predicate vex.VEX `json:"predicate"`
 }
 
 func New() *Attestation {
@@ -36,13 +34,6 @@ func New() *Attestation {
 
 // ToJSON writes the attestation as JSON to the io.Writer w
 func (att *Attestation) ToJSON(w io.Writer) error {
-	if att.Signed {
-		if _, err := w.Write(att.signedData); err != nil {
-			return fmt.Errorf("writing signed attestation")
-		}
-		return nil
-	}
-
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)


### PR DESCRIPTION
This commit drops a vestigial piece of code that printed signed data when serializing an attestation.

/cc @luhring 

Follow-up to https://github.com/openvex/vex/pull/3

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>