### PR TITLE
Add more documentation to `csaf` package and improve `csaf.Open` function

### DIFF
--- a/pkg/csaf/csaf.go
+++ b/pkg/csaf/csaf.go
@@ -96,15 +96,18 @@ type Product struct {
 // Open reads and parses a given file path and returns a CSAF document
 // or an error if the file could not be opened or parsed.
 func Open(path string) (*CSAF, error) {
-	data, err := os.ReadFile(path)
+	fh, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("opening CSAF document: %w", err)
+		return nil, fmt.Errorf("csaf: failed to open document: %w", err)
 	}
+	defer fh.Close()
 
 	csafDoc := &CSAF{}
-	if err := json.Unmarshal(data, csafDoc); err != nil {
-		return nil, fmt.Errorf("unmarshalling CSAF document: %w", err)
+	err = json.NewDecoder(fh).Decode(csafDoc)
+	if err != nil {
+		return nil, fmt.Errorf("csaf: failed to decode document: %w", err)
 	}
+
 	return csafDoc, nil
 }
 

--- a/pkg/csaf/csaf.go
+++ b/pkg/csaf/csaf.go
@@ -139,8 +139,7 @@ func (branch *ProductBranch) FindFirstProduct() string {
 	return ""
 }
 
-// FindFirstProduct recursively searches for the first product in the tree
-// and returns it or nil if no product is found.
+// FindProductIdentifier recursively searches for the first product identifier in the tree
 func (branch *ProductBranch) FindProductIdentifier(helperType, helperValue string) *Product {
 	if len(branch.Product.IdentificationHelper) != 0 {
 		for k := range branch.Product.IdentificationHelper {

--- a/pkg/csaf/csaf.go
+++ b/pkg/csaf/csaf.go
@@ -7,34 +7,76 @@ import (
 	"time"
 )
 
+// CSAF is a Common Security Advisory Framework Version 2.0 document.
+//
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html
 type CSAF struct {
-	Document        DocumentMetadata `json:"document"`
-	ProductTree     ProductBranch    `json:"product_tree"`
-	Vulnerabilities []Vulnerability  `json:"vulnerabilities"`
+	// Document contains metadata about the CSAF document itself.
+	//
+	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#321-document-property
+	Document DocumentMetadata `json:"document"`
+
+	// ProductTree contains information about the product tree (branches only).
+	//
+	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#322-product-tree-property
+	ProductTree ProductBranch `json:"product_tree"`
+
+	// Vulnerabilities contains information about the vulnerabilities,
+	// (i.e. CVEs), associated threats, and product status.
+	//
+	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#323-vulnerabilities-property
+	Vulnerabilities []Vulnerability `json:"vulnerabilities"`
 }
 
+// DocumentMetadata contains metadata about the CSAF document itself.
+//
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#321-document-property
 type DocumentMetadata struct {
 	Title    string   `json:"title"`
 	Tracking Tracking `json:"tracking"`
 }
 
+// Tracking contains information used to track the CSAF document through its lifecycle.
+//
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#32112-document-property---tracking
 type Tracking struct {
 	ID                 string    `json:"id"`
 	CurrentReleaseDate time.Time `json:"current_release_date"`
 }
 
+// Vulnerability contains information about a CVE and its associated threats.
+//
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#323-vulnerabilities-property
 type Vulnerability struct {
-	CVE           string              `json:"cve"`
+	// MITRE standard Common Vulnerabilities and Exposures (CVE) tracking number for the vulnerability.
+	//
+	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3232-vulnerabilities-property---cve
+	CVE string `json:"cve"`
+
+	// Provide details on the status of the referenced product related to the vulnerability.
+	//
+	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3239-vulnerabilities-property---product-status
 	ProductStatus map[string][]string `json:"product_status"`
-	Threats       []ThreatData        `json:"threats"`
+
+	// Provide details of threats associated with a vulnerability.
+	//
+	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#32314-vulnerabilities-property---threats
+	Threats []ThreatData `json:"threats"`
 }
 
+// ThreatData contains information about a threat to a product.
+//
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#32314-vulnerabilities-property---threats
 type ThreatData struct {
 	Category   string   `json:"category"`
 	Details    string   `json:"details"`
 	ProductIDs []string `json:"product_ids"`
 }
 
+// ProductBranch is a recursive struct that contains information about a product and
+// its nested products.
+//
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3221-product-tree-property---branches
 type ProductBranch struct {
 	Category string          `json:"category"`
 	Name     string          `json:"name"`
@@ -42,12 +84,17 @@ type ProductBranch struct {
 	Product  Product         `json:"product,omitempty"`
 }
 
+// Product contains information used to identify a product.
+//
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3124-branches-type---product
 type Product struct {
 	Name                 string            `json:"name"`
 	ID                   string            `json:"product_id"`
 	IdentificationHelper map[string]string `json:"product_identification_helper"`
 }
 
+// Open reads and parses a given file path and returns a CSAF document
+// or an error if the file could not be opened or parsed.
 func Open(path string) (*CSAF, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -61,11 +108,14 @@ func Open(path string) (*CSAF, error) {
 	return csafDoc, nil
 }
 
+// FirstProductName returns the first product name in the product tree
+// or an empty string if no product name is found.
 func (csafDoc *CSAF) FirstProductName() string {
 	return csafDoc.ProductTree.FindFirstProduct()
 }
 
-// FindFirstProduct recursively searches for the first product in the tree
+// FindFirstProduct recursively searches for the first product identifier in the tree
+// and returns it or an empty string if no product identifier is found.
 func (branch *ProductBranch) FindFirstProduct() string {
 	if branch.Product.ID != "" {
 		return branch.Product.ID
@@ -76,6 +126,7 @@ func (branch *ProductBranch) FindFirstProduct() string {
 		return ""
 	}
 
+	// Recursively search for the first product	identifier
 	for _, b := range branch.Branches {
 		if p := b.FindFirstProduct(); p != "" {
 			return p
@@ -85,7 +136,8 @@ func (branch *ProductBranch) FindFirstProduct() string {
 	return ""
 }
 
-// FindProductIdentifier recursively searches for the first product identifier in the tree
+// FindFirstProduct recursively searches for the first product in the tree
+// and returns it or nil if no product is found.
 func (branch *ProductBranch) FindProductIdentifier(helperType, helperValue string) *Product {
 	if len(branch.Product.IdentificationHelper) != 0 {
 		for k := range branch.Product.IdentificationHelper {
@@ -103,6 +155,7 @@ func (branch *ProductBranch) FindProductIdentifier(helperType, helperValue strin
 		return nil
 	}
 
+	// Recursively search for the first identifier
 	for _, b := range branch.Branches {
 		if p := b.FindProductIdentifier(helperType, helperValue); p != nil {
 			return p

--- a/pkg/csaf/doc.go
+++ b/pkg/csaf/doc.go
@@ -1,3 +1,8 @@
+/*
+Copyright 2023 The OpenVEX Authors
+SPDX-License-Identifier: Apache-2.0
+*/
+
 // Package csaf provides a library for Common Security Advisory Framework Version 2.0 (CSAF) documents.
 //
 // https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html

--- a/pkg/csaf/doc.go
+++ b/pkg/csaf/doc.go
@@ -1,0 +1,4 @@
+// Package csaf provides a library for Common Security Advisory Framework Version 2.0 (CSAF) documents.
+//
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html
+package csaf


### PR DESCRIPTION
This PR aims to accomplish two things:
1. Add more `csaf` package documentation, with links to the standard it implements.
2. Improve the `csaf.Open` function, theoretically. Instead of reading the entire file into memory before decoding it, we can read the file contents as needed with [`*encoding/json.Decoder`](https://pkg.go.dev/encoding/json#Decoder).