### PR TITLE
Add support for CSAF 2.0 relationships

### DIFF
--- a/pkg/csaf/csaf.go
+++ b/pkg/csaf/csaf.go
@@ -78,10 +78,22 @@ type ThreatData struct {
 //
 // https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3221-product-tree-property---branches
 type ProductBranch struct {
-	Category string          `json:"category"`
-	Name     string          `json:"name"`
-	Branches []ProductBranch `json:"branches"`
-	Product  Product         `json:"product,omitempty"`
+	Category      string          `json:"category"`
+	Name          string          `json:"name"`
+	Branches      []ProductBranch `json:"branches"`
+	Product       Product         `json:"product,omitempty"`
+	Relationships []Relationship  `json:"relationships"`
+}
+
+// Relationship establishes a link between two existing full_product_name_t elements, allowing
+// the document producer to define a combination of two products that form a new full_product_name entry.
+//
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3224-product-tree-property---relationships
+type Relationship struct {
+	Category            string  `json:"category"`
+	FullProductName     Product `json:"full_product_name"`
+	ProductRef          string  `json:"product_reference"`
+	RelatesToProductRef string  `json:"relates_to_product_reference"`
 }
 
 // Product contains information used to identify a product.

--- a/pkg/csaf/csaf_test.go
+++ b/pkg/csaf/csaf_test.go
@@ -21,7 +21,7 @@ func TestOpen(t *testing.T) {
 	// Vulnerabilities
 	require.Len(t, doc.Vulnerabilities, 1)
 	require.Equal(t, doc.Vulnerabilities[0].CVE, "CVE-2009-4487")
-	require.Len(t, doc.Vulnerabilities[0].ProductStatus, 1)
+	require.Len(t, doc.Vulnerabilities[0].ProductStatus, 2)
 	require.Len(t, doc.Vulnerabilities[0].ProductStatus["known_not_affected"], 1)
 	require.Equal(t, doc.Vulnerabilities[0].ProductStatus["known_not_affected"][0], "CSAFPID-0001")
 }
@@ -52,8 +52,9 @@ func TestListProducts(t *testing.T) {
 	prods := doc.ProductTree.Branches[0].Branches[0].Branches[0].ListProducts()
 	require.Len(t, prods, 1)
 	require.Equal(t, prods[0].IdentificationHelper["purl"], "pkg:golang/github.com/go-homedir@v1.1.0")
+	require.Len(t, doc.ProductTree.Relationships, 1)
 
 	allProds := doc.ProductTree.Branches[0].ListProducts()
 	require.NotNil(t, allProds)
-	require.Len(t, allProds, 2)
+	require.Len(t, allProds, 3)
 }

--- a/pkg/csaf/testdata/csaf.json
+++ b/pkg/csaf/testdata/csaf.json
@@ -48,7 +48,7 @@
               "product_identification_helper": {
                 "purl": "pkg:maven/@1.3.4"
               }
-            },                
+            },
             "branches": [
               {
                 "category": "product_version",
@@ -60,6 +60,17 @@
                     "purl": "pkg:golang/github.com/go-homedir@v1.1.0"
                   }
                 }
+              },
+              {
+                "category": "product_version",
+                "name": "2.2",
+                "product": {
+                  "name": "Example Company ABC 2.2",
+                  "product_id": "INTERNAL-0002",
+                  "product_identification_helper": {
+                    "purl": "pkg:golang/github.com/go-homedir@v1.0.0"
+                  }
+                }
               }
             ],
             "category": "product_name",
@@ -68,6 +79,17 @@
         ],
         "category": "vendor",
         "name": "Example Company"
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "Example Company ABC 2.2",
+          "product_id": "ABC:INTERNAL-0002"
+        },
+        "product_reference": "INTERNAL-0002",
+        "relates_to_product_reference": "ABC"
       }
     ]
   },
@@ -84,6 +106,9 @@
       "product_status": {
         "known_not_affected": [
           "CSAFPID-0001"
+        ],
+        "known_affected": [
+          "ABC:CSAFPID-0002"
         ]
       },
       "threats": [


### PR DESCRIPTION
* Add relationships type to product tree as defined by spec.
* Extend unit test and test data to check relationships.

Spec: https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3224-product-tree-property---relationships