### PR TITLE
Update go libraries to OPEV-0014, OPEV-0015 and spec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - durationcheck
@@ -58,6 +57,7 @@ linters:
     - unused
     - whitespace
     # - cyclop
+    # - depguard
     # - errorlint
     # - exhaustive
     # - exhaustivestruct

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openvex/go-vex
 go 1.19
 
 require (
+	github.com/google/go-cmp v0.5.9
 	github.com/in-toto/in-toto-golang v0.9.0
 	github.com/owenrumney/go-sarif v1.1.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/in-toto/in-toto-golang v0.9.0 h1:tHny7ac4KgtsfrG6ybU8gVOZux2H8jN05AXJ9EBM1XU=
 github.com/in-toto/in-toto-golang v0.9.0/go.mod h1:xsBVrVsHNsB61++S6Dy2vWosKhuA3lUTQd+eF9HdeMo=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/pkg/vex/compat.go
+++ b/pkg/vex/compat.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2023 The OpenVEX Authors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vex
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+type legacyParser func([]byte) (*VEX, error)
+
+// getLegacyVersionParser returns a parser that can read older OpenVEX formats. The
+// project will have a version skew policy and try to support older versions
+// up to a point. If a version is not supported, this function returns nil.
+func getLegacyVersionParser(version string) legacyParser {
+	switch version {
+	case "v0.0.1":
+		return parse001
+	default:
+		return nil
+	}
+}
+
+var parse001 = func(data []byte) (*VEX, error) {
+	oldVex := &vex001{}
+
+	if err := json.Unmarshal(data, oldVex); err != nil {
+		return nil, fmt.Errorf(
+			"decoding OpenVEX v0.0.1 in compatibility mode: %w", err,
+		)
+	}
+
+	newVex := New()
+
+	newVex.Timestamp = oldVex.Timestamp
+	newVex.Author = oldVex.Author
+	newVex.AuthorRole = oldVex.AuthorRole
+	newVex.ID = oldVex.ID
+	newVex.Tooling = oldVex.Tooling
+	ver, err := strconv.Atoi(oldVex.Version)
+	if err == nil {
+		newVex.Version = ver
+	}
+
+	// Transcode the statements
+	for _, oldStmt := range oldVex.Statements {
+		newStmt := Statement{}
+		newStmt.Status = Status(oldStmt.Status)
+		newStmt.StatusNotes = oldStmt.StatusNotes
+		newStmt.ActionStatement = oldStmt.ActionStatement
+		newStmt.ActionStatementTimestamp = oldStmt.ActionStatementTimestamp
+		newStmt.Justification = Justification(oldStmt.Justification)
+		newStmt.ImpactStatement = oldStmt.ImpactStatement
+		newStmt.Timestamp = oldStmt.Timestamp
+
+		// Add the vulnerability
+		newStmt.Vulnerability = Vulnerability{
+			Name:        VulnerabilityID(oldStmt.Vulnerability),
+			Description: oldStmt.VulnDescription,
+		}
+
+		// Transcode the products from the old statement
+		for _, productID := range oldStmt.Products {
+			newProduct := Product{
+				Component: Component{
+					ID: productID,
+				},
+				Subcomponents: []Subcomponent{},
+			}
+
+			for _, sc := range oldStmt.Subcomponents {
+				if sc == "" {
+					continue
+				}
+				newProduct.Subcomponents = append(newProduct.Subcomponents, Subcomponent{
+					Component: Component{
+						ID: sc,
+					},
+				})
+			}
+			newStmt.Products = append(newStmt.Products, newProduct)
+		}
+		newVex.Statements = append(newVex.Statements, newStmt)
+	}
+
+	return &newVex, nil
+}
+
+type vex001 struct {
+	Context    string         `json:"@context"`
+	ID         string         `json:"@id"`
+	Author     string         `json:"author"`
+	AuthorRole string         `json:"role"`
+	Timestamp  *time.Time     `json:"timestamp"`
+	Version    string         `json:"version"`
+	Tooling    string         `json:"tooling,omitempty"`
+	Supplier   string         `json:"supplier,omitempty"`
+	Statements []statement001 `json:"statements"`
+}
+
+type statement001 struct {
+	Vulnerability            string     `json:"vulnerability,omitempty"`
+	VulnDescription          string     `json:"vuln_description,omitempty"`
+	Timestamp                *time.Time `json:"timestamp,omitempty"`
+	Products                 []string   `json:"products,omitempty"`
+	Subcomponents            []string   `json:"subcomponents,omitempty"`
+	Status                   string     `json:"status"`
+	StatusNotes              string     `json:"status_notes,omitempty"`
+	Justification            string     `json:"justification,omitempty"`
+	ImpactStatement          string     `json:"impact_statement,omitempty"`
+	ActionStatement          string     `json:"action_statement,omitempty"`
+	ActionStatementTimestamp *time.Time `json:"action_statement_timestamp,omitempty"`
+}

--- a/pkg/vex/compat_test.go
+++ b/pkg/vex/compat_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 The OpenVEX Authors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vex
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParse001(t *testing.T) {
+	d, err := time.Parse(time.RFC3339, "2023-01-08T18:02:03.647787998-06:00")
+	require.NoError(t, err)
+	for msg, tc := range map[string]struct {
+		path      string
+		shouldErr bool
+		expected  *VEX
+	}{
+		"normal": {
+			"testdata/v0.0.1.json",
+			false,
+			&VEX{
+				Metadata: Metadata{
+					Context:    "https://openvex.dev/ns/" + SpecVersion,
+					ID:         "https://openvex.dev/docs/example/vex-9fb3463de1b57",
+					Author:     "Wolfi J Inkinson",
+					AuthorRole: "Document Creator",
+					Timestamp:  &d,
+					Version:    1,
+				},
+				Statements: []Statement{
+					{
+						Vulnerability: Vulnerability{Name: "CVE-2023-12345"},
+						Products: []Product{
+							{Component: Component{ID: "pkg:apk/wolfi/git@2.39.0-r1?arch=armv7"}, Subcomponents: []Subcomponent{}},
+							{Component: Component{ID: "pkg:apk/wolfi/git@2.39.0-r1?arch=x86_64"}, Subcomponents: []Subcomponent{}},
+						},
+						Status: "fixed",
+					},
+				},
+			},
+		},
+	} {
+		data, err := os.ReadFile(tc.path)
+		require.NoError(t, err, msg)
+		doc, err := parse001(data)
+		if tc.shouldErr {
+			require.Error(t, err, msg)
+			return
+		}
+
+		require.True(t, cmp.Equal(doc.Metadata, tc.expected.Metadata), fmt.Sprintf("%+v + %+v", doc.Metadata, tc.expected.Metadata))
+		require.Equal(t, doc.Statements, tc.expected.Statements, fmt.Sprintf("%+v + %+v", doc.Statements, tc.expected.Statements))
+		require.True(t, cmp.Equal(doc, tc.expected), msg)
+
+		require.NoError(t, err, msg)
+	}
+}

--- a/pkg/vex/compat_test.go
+++ b/pkg/vex/compat_test.go
@@ -29,7 +29,7 @@ func TestParse001(t *testing.T) {
 			false,
 			&VEX{
 				Metadata: Metadata{
-					Context:    "https://openvex.dev/ns/" + SpecVersion,
+					Context:    "https://openvex.dev/ns/v" + SpecVersion,
 					ID:         "https://openvex.dev/docs/example/vex-9fb3463de1b57",
 					Author:     "Wolfi J Inkinson",
 					AuthorRole: "Document Creator",

--- a/pkg/vex/product.go
+++ b/pkg/vex/product.go
@@ -31,7 +31,7 @@ type Component struct {
 	Supplier string `json:"supplier,omitempty"`
 }
 
-// Product abstracts the VEX product into a struct that can identify sofware
+// Product abstracts the VEX product into a struct that can identify software
 // through various means. The main one is the ID field which contains an IRI
 // identifying the product, possibly pointing to another document with more data,
 // like an SBOM. The Product struct also supports naming software using its
@@ -48,7 +48,10 @@ type Subcomponent struct {
 	Component
 }
 
-type IdentifierType string
+type (
+	IdentifierLocator string
+	IdentifierType    string
+)
 
 const (
 	PURL  IdentifierType = "purl"
@@ -56,10 +59,10 @@ const (
 	CPE23 IdentifierType = "cpe23"
 )
 
-type IdentifierLocator string
-
-type Algorithm string
-type Hash string
+type (
+	Algorithm string
+	Hash      string
+)
 
 // The following list of algorithms follows and expands the IANA list at:
 // https://www.iana.org/assignments/named-information/named-information.xhtml

--- a/pkg/vex/product.go
+++ b/pkg/vex/product.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The OpenVEX Authors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vex
+
+// Component abstracts the common construct shared by product and subcomponents
+// allowing OpenVEX statements to point to a piece of software by identifier,
+// hash or identifier.
+//
+// The ID should be an IRI uniquely identifying the product. Software can be
+// referenced as a VEX product or subcomponent using only its IRI or it may be
+// referenced by its crptographic hashes and/or other identifiers but, in no case,
+// must an IRI describe two different pieces of software or used to describe
+// a range of software.
+type Component struct {
+	ID          string                    `json:"@id,omitempty"`
+	Hashes      map[Algorithm]Hash        `json:"hashes,omitempty"`
+	Identifiers map[IdentifierType]string `json:"identifiers,omitempty"`
+}
+
+// Product abstracts the VEX product into a struct that can identify sofware
+// through various means. The main one is the ID field which contains an IRI
+// identifying the product, possibly pointing to another document with more data,
+// like an SBOM. The Product struct also supports naming software using its
+// identifiers and/or cryptographic hashes.
+type Product struct {
+	Component
+	Subcomponents []Subcomponent `json:"subcomponents,omitempty"`
+}
+
+// Subcomponents are nested entries that list the product's components that are
+// related to the statement's vulnerability. The main difference with Product
+// and Subcomponent objects is that a Subcomponent cannot nest components.
+type Subcomponent struct {
+	Component
+}
+
+type Algorithm string
+type Hash string
+
+type IdentifierType string
+type IdentifierLocator string

--- a/pkg/vex/product.go
+++ b/pkg/vex/product.go
@@ -6,8 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package vex
 
 // Component abstracts the common construct shared by product and subcomponents
-// allowing OpenVEX statements to point to a piece of software by identifier,
-// hash or identifier.
+// allowing OpenVEX statements to point to a piece of software by referencing it
+// by hash or identifier.
 //
 // The ID should be an IRI uniquely identifying the product. Software can be
 // referenced as a VEX product or subcomponent using only its IRI or it may be

--- a/pkg/vex/product.go
+++ b/pkg/vex/product.go
@@ -48,8 +48,34 @@ type Subcomponent struct {
 	Component
 }
 
+type IdentifierType string
+
+const (
+	PURL  IdentifierType = "purl"
+	CPE22 IdentifierType = "cpe22"
+	CPE23 IdentifierType = "cpe23"
+)
+
+type IdentifierLocator string
+
 type Algorithm string
 type Hash string
 
-type IdentifierType string
-type IdentifierLocator string
+// The following list of algorithms follows and expands the IANA list at:
+// https://www.iana.org/assignments/named-information/named-information.xhtml
+// It expands it, trying to keep the naming pattern.
+const (
+	MD5        Algorithm = "md5"
+	SHA1       Algorithm = "sha1"
+	SHA256     Algorithm = "sha-256"
+	SHA384     Algorithm = "sha-384"
+	SHA512     Algorithm = "sha-512"
+	SHA3224    Algorithm = "sha3-224"
+	SHA3256    Algorithm = "sha3-256"
+	SHA3384    Algorithm = "sha3-384"
+	SHA3512    Algorithm = "sha3-512"
+	BLAKE2S256 Algorithm = "blake2s-256"
+	BLAKE2B256 Algorithm = "blake2b-256"
+	BLAKE2B512 Algorithm = "blake2b-512"
+	BLAKE3     Algorithm = "blake3"
+)

--- a/pkg/vex/product.go
+++ b/pkg/vex/product.go
@@ -15,9 +15,20 @@ package vex
 // must an IRI describe two different pieces of software or used to describe
 // a range of software.
 type Component struct {
-	ID          string                    `json:"@id,omitempty"`
-	Hashes      map[Algorithm]Hash        `json:"hashes,omitempty"`
+	// ID is an IRI identifying the component. It is optional as the component
+	// can also be identified using hashes or software identifiers.
+	ID string `json:"@id,omitempty"`
+
+	// Hashes is a map of hashes to identify the component using cryptographic
+	// hashes.
+	Hashes map[Algorithm]Hash `json:"hashes,omitempty"`
+
+	// Identifiers is a list of software identifiers that describe the component.
 	Identifiers map[IdentifierType]string `json:"identifiers,omitempty"`
+
+	// Supplier is an optional machine-readable identifier for the supplier of
+	// the component. Valid examples include email address or IRIs.
+	Supplier string `json:"supplier,omitempty"`
 }
 
 // Product abstracts the VEX product into a struct that can identify sofware

--- a/pkg/vex/statement.go
+++ b/pkg/vex/statement.go
@@ -30,11 +30,10 @@ type Statement struct {
 	// was known to be true.
 	Timestamp *time.Time `json:"timestamp,omitempty"`
 
-	// ProductIdentifiers
+	// Product
 	// Product details MUST specify what Status applies to.
 	// Product details MUST include [product_id] and MAY include [subcomponent_id].
-	Products      []string `json:"products,omitempty"`
-	Subcomponents []string `json:"subcomponents,omitempty"`
+	Products []Product `json:"products,omitempty"`
 
 	// A VEX statement MUST provide Status of the vulnerabilities with respect to the
 	// products and components listed in the statement. Status MUST be one of the

--- a/pkg/vex/statement.go
+++ b/pkg/vex/statement.go
@@ -23,8 +23,7 @@ type Statement struct {
 	//
 	// [vul_id] MAY be URIs or URLs.
 	// [vul_id] MAY be arbitrary and MAY be created by the VEX statement [author].
-	Vulnerability   string `json:"vulnerability,omitempty"`
-	VulnDescription string `json:"vuln_description,omitempty"`
+	Vulnerability Vulnerability `json:"vulnerability,omitempty"`
 
 	// Timestamp is the time at which the information expressed in the Statement
 	// was known to be true.
@@ -136,7 +135,8 @@ func (stmt Statement) Validate() error { //nolint:gocritic // turning off for ru
 // The documentTimestamp parameter is needed because statements without timestamps inherit the timestamp of the document.
 func SortStatements(stmts []Statement, documentTimestamp time.Time) {
 	sort.SliceStable(stmts, func(i, j int) bool {
-		vulnComparison := strings.Compare(stmts[i].Vulnerability, stmts[j].Vulnerability)
+		// TODO: Add methods for aliases
+		vulnComparison := strings.Compare(string(stmts[i].Vulnerability.Name), string(stmts[j].Vulnerability.Name))
 		if vulnComparison != 0 {
 			// i.e. different vulnerabilities; sort by string comparison
 			return vulnComparison < 0

--- a/pkg/vex/statement.go
+++ b/pkg/vex/statement.go
@@ -16,6 +16,10 @@ import (
 // [vul_id] for one or more [product_id]s. A VEX Statement exists within a VEX
 // Document.
 type Statement struct {
+	// ID is an optional identifier for the statement. It takes an IRI and must
+	// be unique for each statement in the document.
+	ID string `json:"@id,omitempty"`
+
 	// [vul_id] SHOULD use existing and well known identifiers, for example:
 	// CVE, the Global Security Database (GSD), or a supplier’s vulnerability
 	// tracking system. It is expected that vulnerability identification systems
@@ -28,6 +32,9 @@ type Statement struct {
 	// Timestamp is the time at which the information expressed in the Statement
 	// was known to be true.
 	Timestamp *time.Time `json:"timestamp,omitempty"`
+
+	// LastUpdated records the time when the statement last had a modification
+	LastUpdated *time.Time `json:"last_updated,omitempty"`
 
 	// Product
 	// Product details MUST specify what Status applies to.

--- a/pkg/vex/testdata/v0.0.1-noversion.json
+++ b/pkg/vex/testdata/v0.0.1-noversion.json
@@ -1,0 +1,18 @@
+{
+  "@context": "https://openvex.dev/ns",
+  "@id": "https://openvex.dev/docs/example/vex-9fb3463de1b57",
+  "author": "Wolfi J Inkinson",
+  "role": "Document Creator",
+  "timestamp": "2023-01-08T18:02:03.647787998-06:00",
+  "version": "1",
+  "statements": [
+    {
+      "vulnerability": "CVE-2023-12345",
+      "products": [
+        "pkg:apk/wolfi/git@2.39.0-r1?arch=armv7",
+        "pkg:apk/wolfi/git@2.39.0-r1?arch=x86_64"
+      ],
+      "status": "fixed"
+    }
+  ]
+}

--- a/pkg/vex/testdata/v0.0.1.json
+++ b/pkg/vex/testdata/v0.0.1.json
@@ -1,0 +1,18 @@
+{
+  "@context": "https://openvex.dev/ns/v0.0.1",
+  "@id": "https://openvex.dev/docs/example/vex-9fb3463de1b57",
+  "author": "Wolfi J Inkinson",
+  "role": "Document Creator",
+  "timestamp": "2023-01-08T18:02:03.647787998-06:00",
+  "version": "1",
+  "statements": [
+    {
+      "vulnerability": "CVE-2023-12345",
+      "products": [
+        "pkg:apk/wolfi/git@2.39.0-r1?arch=armv7",
+        "pkg:apk/wolfi/git@2.39.0-r1?arch=x86_64"
+      ],
+      "status": "fixed"
+    }
+  ]
+}

--- a/pkg/vex/testdata/v0.2.0.json
+++ b/pkg/vex/testdata/v0.2.0.json
@@ -1,0 +1,89 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-d4e9020b6d0d26f131d535e055902dd6ccf3e2088bce3079a8cd3588a4b14c78",
+  "author": "The OpenVEX Project <openvex@openssf.org>",
+  "role": "Demo Writer",
+  "timestamp": "2023-07-17T18:28:47.696004345-06:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2023-1255"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+          "subcomponents": [
+            { "@id": "pkg:apk/alpine/libssl3@3.0.8-r3" },
+            { "@id": "pkg:apk/alpine/libcrypto3@3.0.8-r3" }
+          ]
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-2650"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+          "subcomponents": [
+            { "@id": "pkg:apk/alpine/libssl3@3.0.8-r3" },
+            { "@id": "pkg:apk/alpine/libcrypto3@3.0.8-r3" }
+          ]
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+        "vulnerability": {
+          "name": "CVE-2023-2975"
+        },
+        "products": [
+          {
+            "@id": "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+            "subcomponents": [
+              { "@id": "pkg:apk/alpine/libssl3@3.0.8-r3" },
+              { "@id": "pkg:apk/alpine/libcrypto3@3.0.8-r3" }
+            ]
+          }
+        ],
+        "status": "fixed"
+      },
+      {
+        "vulnerability": {
+          "name": "CVE-2023-3446"
+        },
+        "products": [
+          {
+            "@id": "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+            "subcomponents": [
+              { "@id": "pkg:apk/alpine/libssl3@3.0.8-r3" },
+              { "@id": "pkg:apk/alpine/libcrypto3@3.0.8-r3" }
+            ]
+          }
+        ],
+        "status": "not_affected",
+        "justification": "vulnerable_code_not_present",
+        "impact_statement": "affected functions were removed before packaging"
+      },
+      {
+        "vulnerability": {
+          "name": "CVE-2023-3817"
+        },
+        "products": [
+          {
+            "@id": "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+            "subcomponents": [
+              { "@id": "pkg:apk/alpine/libssl3@3.0.8-r3" },
+              { "@id": "pkg:apk/alpine/libcrypto3@3.0.8-r3" }
+            ]
+          }
+        ],
+        "status": "not_affected",
+        "justification": "vulnerable_code_not_present",
+        "impact_statement": "affected functions were removed before packaging"
+      }
+  ]
+}

--- a/pkg/vex/testdata/vex.yaml
+++ b/pkg/vex/testdata/vex.yaml
@@ -5,22 +5,19 @@ author: "Chainguard"
 role: "author"
 timestamp: "2022-08-29T17:48:53.697543267-05:00"
 statements:
-  - vulnerability: "CVE-2022-31030"
+  - vulnerability:
+      name: "CVE-2022-31030"
+      aliases:
+          - "FEDORA-2022-1da581ac6d"
+          - "DSA-5162"
     status: "not_affected"
     justification: "vulnerable_code_not_in_execute_path"
-    action_statement: "Affected library function not called"
-    references:
-      - type: FEDORA
-        ref: "FEDORA-2022-1da581ac6d"
-      - type: "DEBIAN"
-        ref: "DSA-5162"
-  - vulnerability: "CVE-2021-44228"   # Log4j
+    action_statement: "Affected library function not called"      
+  - vulnerability:
+      name: "CVE-2021-44228"   # Log4j
+      aliases:
+        - "FEDORA-2021-66d6c484f3"
+        - "VU#930724"
+        - "cisco-sa-apache-log4j-qRuKNEbd"
     status: "affected"
     action_statement: "Customers are advised to upgrade"
-    references:
-      - type: FEDORA
-        ref: "FEDORA-2021-66d6c484f3"
-      - type: "CERT-VN"
-        ref: "VU#930724"
-      - type: "CISCO"
-        ref: "cisco-sa-apache-log4j-qRuKNEbd"

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -361,7 +361,7 @@ func (vexDoc *VEX) CanonicalHash() (string, error) {
 	//nolint:gocritic
 	for _, s := range stmts {
 		// 4a. Vulnerability
-		cString += fmt.Sprintf(":%s", s.Vulnerability)
+		cString += cstringFromVulnerability(s.Vulnerability)
 		// 4b. Status + Justification
 		cString += fmt.Sprintf(":%s:%s", s.Status, s.Justification)
 		// 4c. Statement time, in unixtime. If it exists, if not the doc's
@@ -408,6 +408,20 @@ func cstringFromComponent(c Component) string {
 	}
 
 	return s
+}
+
+// cstringFromVulnerability returns a string concatenating the vulnerability
+// elements into a reproducible string that can be used to hash or index the
+// vulnerability data or the statement.
+func cstringFromVulnerability(v Vulnerability) string {
+	cString := fmt.Sprintf(":%s:%s", v.ID, v.Name)
+	list := []string{}
+	for i := range v.Aliases {
+		list = append(list, string(v.Aliases[i]))
+	}
+	sort.Strings(list)
+	cString += strings.Join(list, ":")
+	return cString
 }
 
 // GenerateCanonicalID generates an ID for the document. The ID will be

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -30,6 +30,10 @@ const (
 	// [in-toto statements]: https://github.com/in-toto/attestation/blob/main/spec/README.md#statement
 	TypeURI = "https://openvex.dev/ns"
 
+	// SpecVersion is the latest released version of the openvex. This constant
+	// is used to form the context URL when generating new documents.
+	SpecVersion = "0.2.0"
+
 	// DefaultAuthor is the default value for a document's Author field.
 	DefaultAuthor = "Unknown Author"
 
@@ -109,7 +113,7 @@ func New() VEX {
 	}
 	return VEX{
 		Metadata: Metadata{
-			Context:    Context,
+			Context:    fmt.Sprintf("%s/%s", Context, SpecVersion),
 			Author:     DefaultAuthor,
 			AuthorRole: DefaultRole,
 			Version:    1,

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -186,11 +186,11 @@ func (vexDoc *VEX) EffectiveStatement(product, vulnID string) (s *Statement) {
 	SortStatements(statements, t)
 
 	for i := len(statements) - 1; i >= 0; i-- {
-		if statements[i].Vulnerability != vulnID {
+		if statements[i].Vulnerability.ID != vulnID {
 			continue
 		}
 		for _, p := range statements[i].Products {
-			if p == product {
+			if p.ID == product {
 				return &statements[i]
 			}
 		}
@@ -204,8 +204,8 @@ func (vexDoc *VEX) EffectiveStatement(product, vulnID string) (s *Statement) {
 func (vexDoc *VEX) StatementFromID(id string) *Statement {
 	logrus.Warn("vex.StatementFromID is deprecated and will be removed in an upcoming version")
 	for i := range vexDoc.Statements {
-		if vexDoc.Statements[i].Vulnerability == id && len(vexDoc.Statements[i].Products) > 0 {
-			return vexDoc.EffectiveStatement(vexDoc.Statements[i].Products[0], id)
+		if string(vexDoc.Statements[i].Vulnerability.Name) == id && len(vexDoc.Statements[i].Products) > 0 {
+			return vexDoc.EffectiveStatement(vexDoc.Statements[i].Products[0].ID, id)
 		}
 	}
 	return nil
@@ -317,7 +317,7 @@ func OpenCSAF(path string, products []string) (*VEX, error) {
 					}
 
 					v.Statements = append(v.Statements, Statement{
-						Vulnerability:   csafDoc.Vulnerabilities[i].CVE,
+						Vulnerability:   Vulnerability{Name: VulnerabilityID(csafDoc.Vulnerabilities[i].CVE)},
 						Status:          StatusFromCSAF(status),
 						Justification:   "", // Justifications are not machine readable in csaf, it seems
 						ActionStatement: just,

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -409,17 +409,17 @@ func (vexDoc *VEX) CanonicalHash() (string, error) {
 	// 5. Now add the data from each statement
 	//nolint:gocritic
 	for _, s := range stmts {
-		// 4a. Vulnerability
+		// 5a. Vulnerability
 		cString += cstringFromVulnerability(s.Vulnerability)
-		// 4b. Status + Justification
+		// 5b. Status + Justification
 		cString += fmt.Sprintf(":%s:%s", s.Status, s.Justification)
-		// 4c. Statement time, in unixtime. If it exists, if not the doc's
+		// 5c. Statement time, in unixtime. If it exists, if not the doc's
 		if s.Timestamp != nil {
 			cString += fmt.Sprintf(":%d", s.Timestamp.Unix())
 		} else {
 			cString += fmt.Sprintf(":%d", vexDoc.Timestamp.Unix())
 		}
-		// 4d. Sorted product strings
+		// 5d. Sorted product strings
 		prods := []string{}
 		for _, p := range s.Products {
 			prodString := cstringFromComponent(p.Component)
@@ -434,7 +434,7 @@ func (vexDoc *VEX) CanonicalHash() (string, error) {
 		cString += fmt.Sprintf(":%s", strings.Join(prods, ":"))
 	}
 
-	// 5. Hash the string in sha256 and return
+	// 6. Hash the string in sha256 and return
 	h := sha256.New()
 	if _, err := h.Write([]byte(cString)); err != nil {
 		return "", fmt.Errorf("hashing canonicalization string: %w", err)

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -34,7 +34,7 @@ const (
 	DefaultAuthor = "Unknown Author"
 
 	// DefaultRole is the default value for a document's AuthorRole field.
-	DefaultRole = "Document Creator"
+	DefaultRole = ""
 
 	// Context is the URL of the json-ld context definition
 	Context = "https://openvex.dev/ns"
@@ -74,15 +74,19 @@ type Metadata struct {
 	Author string `json:"author"`
 
 	// AuthorRole describes the role of the document Author.
-	AuthorRole string `json:"role"`
+	AuthorRole string `json:"role,omitempty"`
 
 	// Timestamp defines the time at which the document was issued.
 	Timestamp *time.Time `json:"timestamp"`
 
+	// LastUpdated marks the time when the document had its last update. When the
+	// document changes both version and this field should be updated.
+	LastUpdated *time.Time `json:"last_updated,omitempty"`
+
 	// Version is the document version. It must be incremented when any content
 	// within the VEX document changes, including any VEX statements included within
 	// the VEX document.
-	Version string `json:"version"`
+	Version int `json:"version"`
 
 	// Tooling expresses how the VEX document and contained VEX statements were
 	// generated. It's optional. It may specify tools or automated processes used in
@@ -108,7 +112,7 @@ func New() VEX {
 			Context:    Context,
 			Author:     DefaultAuthor,
 			AuthorRole: DefaultRole,
-			Version:    "1",
+			Version:    1,
 			Timestamp:  &now,
 		},
 		Statements: []Statement{},
@@ -348,7 +352,7 @@ func (vexDoc *VEX) CanonicalHash() (string, error) {
 	cString := fmt.Sprintf("%d", vexDoc.Timestamp.Unix())
 
 	// 2. Document version
-	cString += fmt.Sprintf(":%s", vexDoc.Version)
+	cString += fmt.Sprintf(":%d", vexDoc.Version)
 
 	// 3. Author identity
 	cString += fmt.Sprintf(":%s", vexDoc.Author)

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -134,15 +134,28 @@ func genTestDoc(t *testing.T) VEX {
 			{
 				Vulnerability:   "CVE-1234-5678",
 				VulnDescription: "",
-				Products:        []string{"pkg:apk/wolfi/bash@1.0.0"},
-				Status:          "under_investigation",
+				Products: []Product{
+					{
+						Component: Component{
+							ID: "pkg:oci/example@sha256:47fed8868b46b060efb8699dc40e981a0c785650223e03602d8c4493fc75b68c",
+						},
+						Subcomponents: []Subcomponent{
+							{
+								Component: Component{
+									ID: "pkg:apk/wolfi/bash@1.0.0",
+								},
+							},
+						},
+					},
+				},
+				Status: "under_investigation",
 			},
 		},
 	}
 }
 
 func TestCanonicalHash(t *testing.T) {
-	goldenHash := `461bb1de8d85c7a6af96edf24d0e0672726d248500e63c5413f89db0c6710fa0`
+	goldenHash := `3397119e99cb71129dada8fbc96722eb59121839cf9018dc327e0215bc7843bf`
 
 	otherTS, err := time.Parse(time.RFC3339, "2019-01-22T16:36:43-05:00")
 	require.NoError(t, err)
@@ -159,17 +172,18 @@ func TestCanonicalHash(t *testing.T) {
 			func(v *VEX) {
 				v.Statements = append(v.Statements, Statement{
 					Vulnerability: "CVE-2010-543231",
-					Products:      []string{"pkg:apk/wolfi/git@2.0.0"},
-					Status:        "affected",
+					Products: []Product{
+						{Component: Component{ID: "pkg:apk/wolfi/git@2.0.0"}},
+					},
+					Status: "affected",
 				})
 			},
-			"cf392111c8dfee8f6a115780de1eabf292fcd36aafb6eca75952ea7e2d648e21",
+			"0ba39edb13118b7396c0d1ee13d0d38d4a3303381e22e86a1b2c9d723793a832",
 			false,
 		},
 		// Changing metadata should not change hash
 		{
 			func(v *VEX) {
-				v.Author = "123"
 				v.AuthorRole = "abc"
 				v.ID = "298347" // Mmhh...
 				v.Supplier = "Mr Supplier"
@@ -193,9 +207,9 @@ func TestCanonicalHash(t *testing.T) {
 		// Changing products changes the hash
 		{
 			func(v *VEX) {
-				v.Statements[0].Products[0] = "cool router, bro"
+				v.Statements[0].Products[0].ID = "cool router, bro"
 			},
-			"3ba778366d70b4fc656f9c1338a6be26fab55a7d011db4ceddf2f4840080ab3b",
+			"d042a7f2bbf3bd2c59b744cfe310ec11c920f99344eaa95fad115c323217ec33",
 			false,
 		},
 		// Changing document time changes the hash
@@ -203,7 +217,7 @@ func TestCanonicalHash(t *testing.T) {
 			func(v *VEX) {
 				v.Timestamp = &otherTS
 			},
-			"c69a58b923d83f2c0952a508572aec6529801950e9dcac520dfbcbb953fffe52",
+			"aba93636cf64a52949d82b7862f76dd9bd361097e1bbe6881fbac495b933c774",
 			false,
 		},
 		// Same timestamp in statement as doc should not change the hash
@@ -235,7 +249,7 @@ func TestGenerateCanonicalID(t *testing.T) {
 		{
 			// Normal generation
 			prepare:    func(v *VEX) {},
-			expectedID: "https://openvex.dev/docs/public/vex-461bb1de8d85c7a6af96edf24d0e0672726d248500e63c5413f89db0c6710fa0",
+			expectedID: "https://openvex.dev/docs/public/vex-3397119e99cb71129dada8fbc96722eb59121839cf9018dc327e0215bc7843bf",
 		},
 		{
 			// Existing IDs should not be changed

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -124,7 +124,7 @@ func genTestDoc(t *testing.T) VEX {
 			Author:     "John Doe",
 			AuthorRole: "VEX Writer Extraordinaire",
 			Timestamp:  &ts,
-			Version:    "1",
+			Version:    1,
 			Tooling:    "OpenVEX",
 			Supplier:   "Chainguard Inc",
 		},

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -278,3 +278,23 @@ func TestOpenCSAF(t *testing.T) {
 		require.Len(t, doc.Statements, tc.len)
 	}
 }
+
+func TestOpen(t *testing.T) {
+	for m, tc := range map[string]struct {
+		path      string
+		shouldErr bool
+	}{
+		"OpenVEX v0.0.1":              {"testdata/v0.0.1.json", false},
+		"OpenVEX v0.0.1 (no version)": {"testdata/v0.0.1-noversion.json", false},
+		"CSAF document":               {"testdata/csaf.json", false},
+	} {
+		doc, err := Open(tc.path)
+		if tc.shouldErr {
+			require.Error(t, err, m)
+			continue
+		}
+
+		require.NoError(t, err, m)
+		require.NotNil(t, doc, m)
+	}
+}

--- a/pkg/vex/vulnerability.go
+++ b/pkg/vex/vulnerability.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2023 The OpenVEX Authors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vex
+
+// Vulnerability is a struct that captures the vulnerability identifier and
+// its aliases. When defined, the ID field should be an IRI.
+type Vulnerability struct {
+	ID          string            `json:"@id,omitempty"`
+	Name        VulnerabilityID   `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Aliases     []VulnerabilityID `json:"aliases,omitempty"`
+}
+
+// VulnerabilityID is a string that captures a vulnerability identifier. It is
+// a free form string but it is intended to capture the identifiers used by
+// tracking systems.
+type VulnerabilityID string

--- a/pkg/vex/vulnerability.go
+++ b/pkg/vex/vulnerability.go
@@ -8,10 +8,18 @@ package vex
 // Vulnerability is a struct that captures the vulnerability identifier and
 // its aliases. When defined, the ID field should be an IRI.
 type Vulnerability struct {
-	ID          string            `json:"@id,omitempty"`
-	Name        VulnerabilityID   `json:"name,omitempty"`
-	Description string            `json:"description,omitempty"`
-	Aliases     []VulnerabilityID `json:"aliases,omitempty"`
+	//  ID is an IRI to reference the vulnerability in the statement.
+	ID string `json:"@id,omitempty"`
+
+	// Name is the main vulnerability identifier.
+	Name VulnerabilityID `json:"name,omitempty"`
+
+	// Description is a short free form text description of the vulnerability.
+	Description string `json:"description,omitempty"`
+
+	// Aliases is a list of other vulnerability identifier strings that
+	// locate the vulnerability in other tracking systems.
+	Aliases []VulnerabilityID `json:"aliases,omitempty"`
 }
 
 // VulnerabilityID is a string that captures a vulnerability identifier. It is


### PR DESCRIPTION
This pull request updates the go libraries to implement the [first revision to the OpenVEX spec](https://github.com/openvex/spec/pull/35):

- Implements [OPEV-0014: Expansion of the VEX Product Field](https://github.com/openvex/community/issues/14)
- Implements [OPEV-0015: Expansion of the Vulnerability Field](https://github.com/openvex/community/issues/15)
- Minor revisions to the spec to meet final VEX-WG Minimum Requirements for VEX document (https://github.com/openvex/spec/pull/25)