### PR TITLE
Make the default namespace configurable

### DIFF
--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -48,6 +48,10 @@ const (
 	errMsgParse = "error"
 )
 
+// DefaultNamespace is the URL that will be used to generate new IRIs for generated
+// documents and nodes. It is set to the OpenVEX public namespace by default.
+var DefaultNamespace = PublicNamespace
+
 // The VEX type represents a VEX document and all of its contained information.
 type VEX struct {
 	Metadata
@@ -386,7 +390,7 @@ func (vexDoc *VEX) GenerateCanonicalID() (string, error) {
 	}
 
 	// For common namespaced documents we namespace them into /public
-	vexDoc.ID = fmt.Sprintf("%s/public/vex-%s", PublicNamespace, cHash)
+	vexDoc.ID = fmt.Sprintf("%s/public/vex-%s", DefaultNamespace, cHash)
 	return vexDoc.ID, nil
 }
 


### PR DESCRIPTION
This PR introduces a new vex.DefaultNamespace variable that is used to set the namespace used in node and document identifiers. It is set by default to the OpenVEX public namespace.

Fixes: https://github.com/openvex/go-vex/issues/19

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>