### PR TITLE
vex.MergeDocuments()

### DIFF
--- a/pkg/vex/functions_documents.go
+++ b/pkg/vex/functions_documents.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2023 The OpenVEX Authors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vex
+
+import (
+	"sort"
+)
+
+// SortDocuments sorts and returns a slice of documents based on their date.
+// VEXes should be applied sequentially in chronological order as they capture
+// knowledge about an artifact as it changes over time.
+func SortDocuments(docs []*VEX) []*VEX {
+	sort.Slice(docs, func(i, j int) bool {
+		if docs[j].Timestamp == nil {
+			return true
+		}
+		if docs[i].Timestamp == nil {
+			return false
+		}
+		return docs[i].Timestamp.Before(*(docs[j].Timestamp))
+	})
+	return docs
+}

--- a/pkg/vex/functions_documents.go
+++ b/pkg/vex/functions_documents.go
@@ -6,8 +6,121 @@ SPDX-License-Identifier: Apache-2.0
 package vex
 
 import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
 	"sort"
+	"strings"
 )
+
+type MergeOptions struct {
+	DocumentID      string   // ID to use in the new document
+	Author          string   // Author to use in the new document
+	AuthorRole      string   // Role of the document author
+	Products        []string // Product IDs to consider
+	Vulnerabilities []string // IDs of vulnerabilities to merge
+}
+
+// MergeDocuments is a convenience wrapper over MergeDocumentsWithOptions
+// that does not take options.
+func MergeDocuments(docs []*VEX) (*VEX, error) {
+	return MergeDocumentsWithOptions(&MergeOptions{}, docs)
+}
+
+// Merge combines the statements from a number of documents into
+// a new one, preserving time context from each of them.
+func MergeDocumentsWithOptions(mergeOpts *MergeOptions, docs []*VEX) (*VEX, error) {
+	if len(docs) == 0 {
+		return nil, fmt.Errorf("at least one vex document is required to merge")
+	}
+
+	docID := mergeOpts.DocumentID
+	// If no document id is specified we compute a
+	// deterministic ID using the merged docs
+	if docID == "" {
+		ids := []string{}
+		for i, d := range docs {
+			if d.ID == "" {
+				ids = append(ids, fmt.Sprintf("VEX-DOC-%d", i))
+			} else {
+				ids = append(ids, d.ID)
+			}
+		}
+
+		sort.Strings(ids)
+		h := sha256.New()
+		h.Write([]byte(strings.Join(ids, ":")))
+		// Hash the sorted IDs list
+		docID = fmt.Sprintf("merged-vex-%x", h.Sum(nil))
+	}
+
+	newDoc := New()
+
+	newDoc.ID = docID
+	if author := mergeOpts.Author; author != "" {
+		newDoc.Author = author
+	}
+	if authorRole := mergeOpts.AuthorRole; authorRole != "" {
+		newDoc.AuthorRole = authorRole
+	}
+
+	ss := []Statement{}
+
+	// Create an inverse dict of products and vulnerabilities to filter
+	// these will only be used if ids to filter on are defined in the options.
+	iProds := map[string]struct{}{}
+	iVulns := map[string]struct{}{}
+	for _, id := range mergeOpts.Products {
+		iProds[id] = struct{}{}
+	}
+	for _, id := range mergeOpts.Vulnerabilities {
+		iVulns[id] = struct{}{}
+	}
+
+	for _, doc := range docs {
+		for _, s := range doc.Statements { //nolint:gocritic // this IS supposed to copy
+			matchesProduct := false
+			for id := range iProds {
+				if s.MatchesProduct(id, "") {
+					matchesProduct = true
+					break
+				}
+			}
+			if len(iProds) > 0 && !matchesProduct {
+				continue
+			}
+
+			matchesVuln := false
+			for id := range iVulns {
+				if s.Vulnerability.Matches(id) {
+					matchesVuln = true
+					break
+				}
+			}
+			if len(iVulns) > 0 && !matchesVuln {
+				continue
+			}
+
+			// If statement does not have a timestamp, cascade
+			// the timestamp down from the document.
+			// See https://github.com/chainguard-dev/vex/issues/49
+			if s.Timestamp == nil {
+				if doc.Timestamp == nil {
+					return nil, errors.New("unable to cascade timestamp from doc to timeless statement")
+				}
+				s.Timestamp = doc.Timestamp
+			}
+
+			ss = append(ss, s)
+		}
+	}
+
+	SortStatements(ss, *newDoc.Metadata.Timestamp)
+
+	newDoc.Statements = ss
+
+	return &newDoc, nil
+}
 
 // SortDocuments sorts and returns a slice of documents based on their date.
 // VEXes should be applied sequentially in chronological order as they capture

--- a/pkg/vex/functions_documents_test.go
+++ b/pkg/vex/functions_documents_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2023 The OpenVEX Authors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMerge(t *testing.T) {
+	doc1, err := Open("testdata/v001-1.vex.json")
+	require.NoError(t, err)
+	doc2, err := Open("testdata/v001-2.vex.json")
+	require.NoError(t, err)
+
+	doc3, err := Open("testdata/v020-1.vex.json")
+	require.NoError(t, err)
+	doc4, err := Open("testdata/v020-2.vex.json")
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		opts        MergeOptions
+		docs        []*VEX
+		expectedDoc *VEX
+		shouldErr   bool
+	}{
+		// Zero docs should fail
+		{
+			opts:        MergeOptions{},
+			docs:        []*VEX{},
+			expectedDoc: &VEX{},
+			shouldErr:   true,
+		},
+		// One doc results in the same doc
+		{
+			opts:        MergeOptions{},
+			docs:        []*VEX{doc1},
+			expectedDoc: doc1,
+			shouldErr:   false,
+		},
+		// Two docs, as they are
+		{
+			opts: MergeOptions{},
+			docs: []*VEX{doc1, doc2},
+			expectedDoc: &VEX{
+				Metadata: Metadata{},
+				Statements: []Statement{
+					doc1.Statements[0],
+					doc2.Statements[0],
+				},
+			},
+			shouldErr: false,
+		},
+		// Two docs, filter product
+		{
+			opts: MergeOptions{
+				Products: []string{"pkg:apk/wolfi/git@2.41.0-1"},
+			},
+			docs: []*VEX{doc3, doc4},
+			expectedDoc: &VEX{
+				Metadata: Metadata{},
+				Statements: []Statement{
+					doc4.Statements[0],
+				},
+			},
+			shouldErr: false,
+		},
+		// Two docs, filter vulnerability
+		{
+			opts: MergeOptions{
+				Vulnerabilities: []string{"CVE-9876-54321"},
+			},
+			docs: []*VEX{doc3, doc4},
+			expectedDoc: &VEX{
+				Metadata: Metadata{},
+				Statements: []Statement{
+					doc3.Statements[0],
+				},
+			},
+			shouldErr: false,
+		},
+	} {
+		doc, err := MergeDocuments(&tc.opts, tc.docs)
+		if tc.shouldErr {
+			require.Error(t, err)
+			continue
+		}
+
+		// Check doc
+		require.Len(t, doc.Statements, len(tc.expectedDoc.Statements))
+		require.Equal(t, doc.Statements, tc.expectedDoc.Statements)
+	}
+}

--- a/pkg/vex/functions_documents_test.go
+++ b/pkg/vex/functions_documents_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMerge(t *testing.T) {
+func TestMergeDocumentsWithOptions(t *testing.T) {
 	doc1, err := Open("testdata/v001-1.vex.json")
 	require.NoError(t, err)
 	doc2, err := Open("testdata/v001-2.vex.json")
@@ -84,7 +84,7 @@ func TestMerge(t *testing.T) {
 			shouldErr: false,
 		},
 	} {
-		doc, err := MergeDocuments(&tc.opts, tc.docs)
+		doc, err := MergeDocumentsWithOptions(&tc.opts, tc.docs)
 		if tc.shouldErr {
 			require.Error(t, err)
 			continue

--- a/pkg/vex/functions_files.go
+++ b/pkg/vex/functions_files.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2023 The OpenVEX Authors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vex
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/openvex/go-vex/pkg/csaf"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+// Load reads the VEX document file at the given path and returns a decoded VEX
+// object. If Load is unable to read the file or decode the document, it returns
+// an error.
+func Load(path string) (*VEX, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("loading VEX file: %w", err)
+	}
+
+	return Parse(data)
+}
+
+// Parse parses an OpenVEX document in the latest version from the data byte array.
+func Parse(data []byte) (*VEX, error) {
+	vexDoc := &VEX{}
+	if err := json.Unmarshal(data, vexDoc); err != nil {
+		return nil, fmt.Errorf("%s: %w", errMsgParse, err)
+	}
+	return vexDoc, nil
+}
+
+// OpenYAML opens a VEX file in YAML format.
+func OpenYAML(path string) (*VEX, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening YAML file: %w", err)
+	}
+	vexDoc := New()
+	if err := yaml.Unmarshal(data, &vexDoc); err != nil {
+		return nil, fmt.Errorf("unmarshalling VEX data: %w", err)
+	}
+	return &vexDoc, nil
+}
+
+// OpenJSON opens an OpenVEX file in JSON format.
+func OpenJSON(path string) (*VEX, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening JSON file: %w", err)
+	}
+	vexDoc := New()
+	if err := json.Unmarshal(data, &vexDoc); err != nil {
+		return nil, fmt.Errorf("unmarshalling VEX data: %w", err)
+	}
+	return &vexDoc, nil
+}
+
+// parseContext light parses a JSON document to look for the OpenVEX context locator
+func parseContext(rawDoc []byte) (string, error) {
+	pd := struct {
+		Context string `json:"@context"`
+	}{}
+
+	if err := json.Unmarshal(rawDoc, &pd); err != nil {
+		return "", fmt.Errorf("parsing context from json data: %w", err)
+	}
+
+	if strings.HasPrefix(pd.Context, Context) {
+		return pd.Context, nil
+	}
+	return "", nil
+}
+
+// Open tries to autodetect the vex format and open it
+func Open(path string) (*VEX, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening VEX file: %w", err)
+	}
+
+	documentContextLocator, err := parseContext(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if documentContextLocator == ContextLocator() {
+		return Parse(data)
+	} else if documentContextLocator != "" {
+		version := strings.TrimPrefix(documentContextLocator, Context)
+		version = strings.TrimPrefix(version, "/")
+
+		// If version is nil, then we assume v0.0.1
+		if version == "" {
+			version = "v0.0.1"
+		}
+
+		parser := getLegacyVersionParser(version)
+		if parser == nil {
+			return nil, fmt.Errorf("unable to get parser for version %s", version)
+		}
+
+		doc, err := parser(data)
+		if err != nil {
+			return nil, fmt.Errorf("parsing document: %w", err)
+		}
+
+		return doc, nil
+	}
+
+	if bytes.Contains(data, []byte(`"csaf_version"`)) {
+		logrus.Info("Abriendo CSAF")
+
+		doc, err := OpenCSAF(path, []string{})
+		if err != nil {
+			return nil, fmt.Errorf("attempting to open csaf doc: %w", err)
+		}
+		return doc, nil
+	}
+
+	return nil, fmt.Errorf("unable to detect document format reading %s", path)
+}
+
+// OpenCSAF opens a CSAF document and builds a VEX object from it.
+func OpenCSAF(path string, products []string) (*VEX, error) {
+	csafDoc, err := csaf.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening csaf doc: %w", err)
+	}
+
+	productDict := map[string]string{}
+	filterDict := map[string]string{}
+	for _, pid := range products {
+		filterDict[pid] = pid
+	}
+
+	prods := csafDoc.ProductTree.ListProducts()
+	for _, sp := range prods {
+		// Check if we need to filter
+		if len(filterDict) > 0 {
+			foundID := false
+			for _, i := range sp.IdentificationHelper {
+				if _, ok := filterDict[i]; ok {
+					foundID = true
+					break
+				}
+			}
+			_, ok := filterDict[sp.ID]
+			if !foundID && !ok {
+				continue
+			}
+		}
+
+		for _, h := range sp.IdentificationHelper {
+			productDict[sp.ID] = h
+		}
+	}
+
+	// Create the vex doc
+	v := &VEX{
+		Metadata: Metadata{
+			ID:         csafDoc.Document.Tracking.ID,
+			Author:     "",
+			AuthorRole: "",
+			Timestamp:  &time.Time{},
+		},
+		Statements: []Statement{},
+	}
+
+	// Cycle the CSAF vulns list and get those that apply
+	for i := range csafDoc.Vulnerabilities {
+		for status, docProducts := range csafDoc.Vulnerabilities[i].ProductStatus {
+			for _, productID := range docProducts {
+				if _, ok := productDict[productID]; ok {
+					// Check we have a valid status
+					if StatusFromCSAF(status) == "" {
+						return nil, fmt.Errorf("invalid status for product %s", productID)
+					}
+
+					// TODO search the threats struct for justification, etc
+					just := ""
+					for _, t := range csafDoc.Vulnerabilities[i].Threats {
+						// Search the threats for a justification
+						for _, p := range t.ProductIDs {
+							if p == productID {
+								just = t.Details
+							}
+						}
+					}
+
+					v.Statements = append(v.Statements, Statement{
+						Vulnerability:   Vulnerability{Name: VulnerabilityID(csafDoc.Vulnerabilities[i].CVE)},
+						Status:          StatusFromCSAF(status),
+						Justification:   "", // Justifications are not machine readable in csaf, it seems
+						ActionStatement: just,
+						Products: []Product{
+							{
+								Component: Component{
+									ID: productID,
+								},
+							},
+						},
+					})
+				}
+			}
+		}
+	}
+
+	return v, nil
+}

--- a/pkg/vex/functions_files.go
+++ b/pkg/vex/functions_files.go
@@ -217,3 +217,27 @@ func OpenCSAF(path string, products []string) (*VEX, error) {
 
 	return v, nil
 }
+
+// MergeFilesWithOptions opens a list of vex documents and after parsing them
+// merges them into a single file using the specified merge options.
+func MergeFilesWithOptions(mergeOpts *MergeOptions, filePaths []string) (*VEX, error) {
+	vexDocs := []*VEX{}
+	for i := range filePaths {
+		doc, err := Open(filePaths[i])
+		if err != nil {
+			return nil, fmt.Errorf("opening %s: %w", filePaths[i], err)
+		}
+		vexDocs = append(vexDocs, doc)
+	}
+	doc, err := MergeDocumentsWithOptions(mergeOpts, vexDocs)
+	if err != nil {
+		return nil, fmt.Errorf("merging opened files: %w", err)
+	}
+	return doc, nil
+}
+
+// MergeFiles is a convenience wrapper around MergeFilesWithOptions that
+// does not take options but performs the merge using the default options
+func MergeFiles(filePaths []string) (*VEX, error) {
+	return MergeFilesWithOptions(&MergeOptions{}, filePaths)
+}

--- a/pkg/vex/functions_files_test.go
+++ b/pkg/vex/functions_files_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2023 The OpenVEX Authors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vex
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	for m, tc := range map[string]struct {
+		path      string
+		product   string
+		vulns     []string
+		shouldErr bool
+	}{
+		// Previous versions fail on test
+		"OpenVEX v0.0.1": {"testdata/v0.0.1.json", "", []string{}, true},
+		// Current version
+		"OpenVEX v0.2.0": {"testdata/v0.2.0.json", "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126", []string{"CVE-2023-1255", "CVE-2023-2650", "CVE-2023-2975", "CVE-2023-3446", "CVE-2023-3817"}, false},
+	} {
+		data, err := os.ReadFile(tc.path)
+		require.NoError(t, err)
+
+		doc, err := Parse(data)
+		if tc.shouldErr {
+			require.Error(t, err, m)
+			continue
+		}
+
+		require.NoError(t, err, fmt.Errorf("%s: reading %s", m, tc.path))
+		require.NotNil(t, doc, m)
+
+		require.Equal(t, doc.Context, ContextLocator())
+		require.Len(t, doc.Statements, 5)
+
+		vulns := []string{}
+		for _, s := range doc.Statements {
+			vulns = append(vulns, string(s.Vulnerability.Name))
+			require.Equal(t, tc.product, s.Products[0].ID)
+		}
+		sort.Strings(vulns)
+		require.Equal(t, vulns, tc.vulns, m)
+	}
+}
+
+func TestLoadYAML(t *testing.T) {
+	vexDoc, err := OpenYAML("testdata/vex.yaml")
+	require.NoError(t, err)
+
+	require.Len(t, vexDoc.Statements, 2)
+}
+
+func TestLoadCSAF(t *testing.T) {
+	vexDoc, err := OpenCSAF("testdata/csaf.json", []string{})
+	require.NoError(t, err)
+	require.Len(t, vexDoc.Statements, 1)
+	require.Len(t, vexDoc.Statements[0].Products, 1)
+	require.Equal(t, "CVE-2009-4487", string(vexDoc.Statements[0].Vulnerability.Name))
+	require.Equal(t, vexDoc.Statements[0].Status, StatusNotAffected)
+	require.Equal(t, vexDoc.Metadata.ID, "2022-EVD-UC-01-NA-001")
+}
+
+func TestOpenCSAF(t *testing.T) {
+	for _, tc := range []struct {
+		doc string
+		len int
+		id  []string
+	}{
+		{"testdata/csaf.json", 1, []string{"CSAFPID-0001"}},
+		{"testdata/csaf.json", 1, []string{"pkg:golang/github.com/go-homedir@v1.2.0"}},
+	} {
+		doc, err := OpenCSAF(tc.doc, tc.id)
+		require.NoError(t, err)
+		require.NotNil(t, doc)
+		require.Len(t, doc.Statements, tc.len)
+	}
+}
+
+func TestOpen(t *testing.T) {
+	for m, tc := range map[string]struct {
+		path      string
+		shouldErr bool
+	}{
+		"OpenVEX v0.0.1":              {"testdata/v0.0.1.json", false},
+		"OpenVEX v0.0.1 (no version)": {"testdata/v0.0.1-noversion.json", false},
+		"OpenVEX v0.2.0":              {"testdata/v0.2.0.json", false},
+		"CSAF document":               {"testdata/csaf.json", false},
+	} {
+		doc, err := Open(tc.path)
+		if tc.shouldErr {
+			require.Error(t, err, m)
+			continue
+		}
+
+		require.NoError(t, err, m)
+		require.NotNil(t, doc, m)
+	}
+}

--- a/pkg/vex/testdata/v001-1.vex.json
+++ b/pkg/vex/testdata/v001-1.vex.json
@@ -1,0 +1,16 @@
+{
+    "@context": "https://openvex.dev/ns",
+    "@id": "my-vexdoc2",
+	"format": "text/vex+json",
+	"author": "John Doe",
+	"role": "vex issuer",	
+	"statements": [
+        {
+            "timestamp": "2022-12-22T16:36:43-05:00",
+            "products": ["pkg:apk/wolfi/bash@1.0.0"],
+            "vulnerability": "CVE-1234-5678",
+            "status": "under_investigation",
+            "status_notes": ""
+        }
+    ]
+}

--- a/pkg/vex/testdata/v001-2.vex.json
+++ b/pkg/vex/testdata/v001-2.vex.json
@@ -1,0 +1,15 @@
+{
+    "@context": "https://openvex.dev/ns",
+    "@id": "my-vexdoc2",
+	"format": "text/vex+json",
+	"author": "John Doe",
+	"role": "vex issuer",	
+    "statements": [
+        {
+            "timestamp": "2022-12-22T20:56:05-05:00",
+            "products": ["pkg:apk/wolfi/bash@1.0.0"],
+            "vulnerability": "CVE-1234-5678",
+            "status": "fixed"
+        }
+    ]
+}

--- a/pkg/vex/testdata/v020-1.vex.json
+++ b/pkg/vex/testdata/v020-1.vex.json
@@ -1,0 +1,16 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-3f59b4dffdeae0183e5e6a9d7a2461fdf86a03c079f4129050bb462eca366beb",
+  "author": "John Doe",
+  "role": "Senior Trusted VEX Issuer",
+  "statements": [
+    {
+      "timestamp": "2022-12-22T16:36:43-05:00",
+      "products": [
+        { "@id": "pkg:apk/wolfi/bash@1.0.0" }
+      ],
+      "vulnerability": { "name": "CVE-9876-54321" },
+      "status": "under_investigation"
+    }
+  ]
+}

--- a/pkg/vex/testdata/v020-2.vex.json
+++ b/pkg/vex/testdata/v020-2.vex.json
@@ -1,0 +1,16 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-99f523e8cec348eb9917eefe85cd335410946391b959a8b6dab80f3514c8546c",
+  "author": "John Doe",
+  "role": "Senior Trusted VEX Issuer",
+  "statements": [
+    {
+      "timestamp": "2022-12-22T16:36:43-05:00",
+      "products": [
+        { "@id": "pkg:apk/wolfi/git@2.41.0-1" }
+      ],
+      "vulnerability": { "name": "CVE-1234-5678" },
+      "status": "under_investigation"
+    }
+  ]
+}

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -6,7 +6,6 @@ SPDX-License-Identifier: Apache-2.0
 package vex
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -19,9 +18,6 @@ import (
 
 	"github.com/package-url/packageurl-go"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
-
-	"github.com/openvex/go-vex/pkg/csaf"
 )
 
 const (
@@ -124,53 +120,6 @@ func New() VEX {
 	}
 }
 
-// Load reads the VEX document file at the given path and returns a decoded VEX
-// object. If Load is unable to read the file or decode the document, it returns
-// an error.
-func Load(path string) (*VEX, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("loading VEX file: %w", err)
-	}
-
-	return Parse(data)
-}
-
-// Parse parses an OpenVEX document in the latest version from the data byte array.
-func Parse(data []byte) (*VEX, error) {
-	vexDoc := &VEX{}
-	if err := json.Unmarshal(data, vexDoc); err != nil {
-		return nil, fmt.Errorf("%s: %w", errMsgParse, err)
-	}
-	return vexDoc, nil
-}
-
-// OpenYAML opens a VEX file in YAML format.
-func OpenYAML(path string) (*VEX, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("opening YAML file: %w", err)
-	}
-	vexDoc := New()
-	if err := yaml.Unmarshal(data, &vexDoc); err != nil {
-		return nil, fmt.Errorf("unmarshalling VEX data: %w", err)
-	}
-	return &vexDoc, nil
-}
-
-// OpenJSON opens an OpenVEX file in JSON format.
-func OpenJSON(path string) (*VEX, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("opening JSON file: %w", err)
-	}
-	vexDoc := New()
-	if err := json.Unmarshal(data, &vexDoc); err != nil {
-		return nil, fmt.Errorf("unmarshalling VEX data: %w", err)
-	}
-	return &vexDoc, nil
-}
-
 // ToJSON serializes the VEX document to JSON and writes it to the passed writer.
 func (vexDoc *VEX) ToJSON(w io.Writer) error {
 	enc := json.NewEncoder(w)
@@ -241,175 +190,6 @@ func (vexDoc *VEX) Matches(vulnID, product string, subcomponents []string) []Sta
 
 	SortStatements(matches, t)
 	return matches
-}
-
-// SortDocuments sorts and returns a slice of documents based on their date.
-// VEXes should be applied sequentially in chronological order as they capture
-// knowledge about an artifact as it changes over time.
-func SortDocuments(docs []*VEX) []*VEX {
-	sort.Slice(docs, func(i, j int) bool {
-		if docs[j].Timestamp == nil {
-			return true
-		}
-		if docs[i].Timestamp == nil {
-			return false
-		}
-		return docs[i].Timestamp.Before(*(docs[j].Timestamp))
-	})
-	return docs
-}
-
-// parseContext light parses a JSON document to look for the OpenVEX context locator
-func parseContext(rawDoc []byte) (string, error) {
-	pd := struct {
-		Context string `json:"@context"`
-	}{}
-
-	if err := json.Unmarshal(rawDoc, &pd); err != nil {
-		return "", fmt.Errorf("parsing context from json data: %w", err)
-	}
-
-	if strings.HasPrefix(pd.Context, Context) {
-		return pd.Context, nil
-	}
-	return "", nil
-}
-
-// Open tries to autodetect the vex format and open it
-func Open(path string) (*VEX, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("opening VEX file: %w", err)
-	}
-
-	documentContextLocator, err := parseContext(data)
-	if err != nil {
-		return nil, err
-	}
-
-	if documentContextLocator == ContextLocator() {
-		return Parse(data)
-	} else if documentContextLocator != "" {
-		version := strings.TrimPrefix(documentContextLocator, Context)
-		version = strings.TrimPrefix(version, "/")
-
-		// If version is nil, then we assume v0.0.1
-		if version == "" {
-			version = "v0.0.1"
-		}
-
-		parser := getLegacyVersionParser(version)
-		if parser == nil {
-			return nil, fmt.Errorf("unable to get parser for version %s", version)
-		}
-
-		doc, err := parser(data)
-		if err != nil {
-			return nil, fmt.Errorf("parsing document: %w", err)
-		}
-
-		return doc, nil
-	}
-
-	if bytes.Contains(data, []byte(`"csaf_version"`)) {
-		logrus.Info("Abriendo CSAF")
-
-		doc, err := OpenCSAF(path, []string{})
-		if err != nil {
-			return nil, fmt.Errorf("attempting to open csaf doc: %w", err)
-		}
-		return doc, nil
-	}
-
-	return nil, fmt.Errorf("unable to detect document format reading %s", path)
-}
-
-// OpenCSAF opens a CSAF document and builds a VEX object from it.
-func OpenCSAF(path string, products []string) (*VEX, error) {
-	csafDoc, err := csaf.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("opening csaf doc: %w", err)
-	}
-
-	productDict := map[string]string{}
-	filterDict := map[string]string{}
-	for _, pid := range products {
-		filterDict[pid] = pid
-	}
-
-	prods := csafDoc.ProductTree.ListProducts()
-	for _, sp := range prods {
-		// Check if we need to filter
-		if len(filterDict) > 0 {
-			foundID := false
-			for _, i := range sp.IdentificationHelper {
-				if _, ok := filterDict[i]; ok {
-					foundID = true
-					break
-				}
-			}
-			_, ok := filterDict[sp.ID]
-			if !foundID && !ok {
-				continue
-			}
-		}
-
-		for _, h := range sp.IdentificationHelper {
-			productDict[sp.ID] = h
-		}
-	}
-
-	// Create the vex doc
-	v := &VEX{
-		Metadata: Metadata{
-			ID:         csafDoc.Document.Tracking.ID,
-			Author:     "",
-			AuthorRole: "",
-			Timestamp:  &time.Time{},
-		},
-		Statements: []Statement{},
-	}
-
-	// Cycle the CSAF vulns list and get those that apply
-	for i := range csafDoc.Vulnerabilities {
-		for status, docProducts := range csafDoc.Vulnerabilities[i].ProductStatus {
-			for _, productID := range docProducts {
-				if _, ok := productDict[productID]; ok {
-					// Check we have a valid status
-					if StatusFromCSAF(status) == "" {
-						return nil, fmt.Errorf("invalid status for product %s", productID)
-					}
-
-					// TODO search the threats struct for justification, etc
-					just := ""
-					for _, t := range csafDoc.Vulnerabilities[i].Threats {
-						// Search the threats for a justification
-						for _, p := range t.ProductIDs {
-							if p == productID {
-								just = t.Details
-							}
-						}
-					}
-
-					v.Statements = append(v.Statements, Statement{
-						Vulnerability:   Vulnerability{Name: VulnerabilityID(csafDoc.Vulnerabilities[i].CVE)},
-						Status:          StatusFromCSAF(status),
-						Justification:   "", // Justifications are not machine readable in csaf, it seems
-						ActionStatement: just,
-						Products: []Product{
-							{
-								Component: Component{
-									ID: productID,
-								},
-							},
-						},
-					})
-				}
-			}
-		}
-	}
-
-	return v, nil
 }
 
 // CanonicalHash returns a hash representing the state of impact statements

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -7,30 +7,11 @@ package vex
 
 import (
 	"fmt"
-	"os"
-	"sort"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestLoadYAML(t *testing.T) {
-	vexDoc, err := OpenYAML("testdata/vex.yaml")
-	require.NoError(t, err)
-
-	require.Len(t, vexDoc.Statements, 2)
-}
-
-func TestLoadCSAF(t *testing.T) {
-	vexDoc, err := OpenCSAF("testdata/csaf.json", []string{})
-	require.NoError(t, err)
-	require.Len(t, vexDoc.Statements, 1)
-	require.Len(t, vexDoc.Statements[0].Products, 1)
-	require.Equal(t, "CVE-2009-4487", string(vexDoc.Statements[0].Vulnerability.Name))
-	require.Equal(t, vexDoc.Statements[0].Status, StatusNotAffected)
-	require.Equal(t, vexDoc.Metadata.ID, "2022-EVD-UC-01-NA-001")
-}
 
 func TestEffectiveStatement(t *testing.T) {
 	date1 := time.Date(2023, 4, 17, 20, 34, 58, 0, time.UTC)
@@ -262,80 +243,6 @@ func TestGenerateCanonicalID(t *testing.T) {
 		id, err := doc.GenerateCanonicalID()
 		require.NoError(t, err)
 		require.Equal(t, tc.expectedID, id)
-	}
-}
-
-func TestOpenCSAF(t *testing.T) {
-	for _, tc := range []struct {
-		doc string
-		len int
-		id  []string
-	}{
-		{"testdata/csaf.json", 1, []string{"CSAFPID-0001"}},
-		{"testdata/csaf.json", 1, []string{"pkg:golang/github.com/go-homedir@v1.2.0"}},
-	} {
-		doc, err := OpenCSAF(tc.doc, tc.id)
-		require.NoError(t, err)
-		require.NotNil(t, doc)
-		require.Len(t, doc.Statements, tc.len)
-	}
-}
-
-func TestOpen(t *testing.T) {
-	for m, tc := range map[string]struct {
-		path      string
-		shouldErr bool
-	}{
-		"OpenVEX v0.0.1":              {"testdata/v0.0.1.json", false},
-		"OpenVEX v0.0.1 (no version)": {"testdata/v0.0.1-noversion.json", false},
-		"OpenVEX v0.2.0":              {"testdata/v0.2.0.json", false},
-		"CSAF document":               {"testdata/csaf.json", false},
-	} {
-		doc, err := Open(tc.path)
-		if tc.shouldErr {
-			require.Error(t, err, m)
-			continue
-		}
-
-		require.NoError(t, err, m)
-		require.NotNil(t, doc, m)
-	}
-}
-
-func TestParse(t *testing.T) {
-	for m, tc := range map[string]struct {
-		path      string
-		product   string
-		vulns     []string
-		shouldErr bool
-	}{
-		// Previous versions fail on test
-		"OpenVEX v0.0.1": {"testdata/v0.0.1.json", "", []string{}, true},
-		// Current version
-		"OpenVEX v0.2.0": {"testdata/v0.2.0.json", "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126", []string{"CVE-2023-1255", "CVE-2023-2650", "CVE-2023-2975", "CVE-2023-3446", "CVE-2023-3817"}, false},
-	} {
-		data, err := os.ReadFile(tc.path)
-		require.NoError(t, err)
-
-		doc, err := Parse(data)
-		if tc.shouldErr {
-			require.Error(t, err, m)
-			continue
-		}
-
-		require.NoError(t, err, fmt.Errorf("%s: reading %s", m, tc.path))
-		require.NotNil(t, doc, m)
-
-		require.Equal(t, doc.Context, ContextLocator())
-		require.Len(t, doc.Statements, 5)
-
-		vulns := []string{}
-		for _, s := range doc.Statements {
-			vulns = append(vulns, string(s.Vulnerability.Name))
-			require.Equal(t, tc.product, s.Products[0].ID)
-		}
-		sort.Strings(vulns)
-		require.Equal(t, vulns, tc.vulns, m)
 	}
 }
 


### PR DESCRIPTION
This PR does two things:

1. it reorganizes the vex package to break it into more manageable files, functions and test s are moved to their own files to leave the main vex object in the original vex.go
2. It introduces new `vex.MergeDocuments()` and `vex.MergeDocumentsWithOptions()` in 7d0390c33341cf70729a9bc5f5232be3ad67cb70 which are ports from the functions in `vexctl` that merge documents into one. This lets the vex go module offer that functionality without having to import the whole vexctl CLI
3. Adds new `vex.MergeFiles()` and `vex.MergeFilesWithOptions()` that do the same but reading straight from vex files.
This is the last pr we will do before cutting a new release of openvex/go-vex

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>