### PR TITLE
Add publish-release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 The OpenVEX Authors
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # needed to write releases
+
+    steps:
+      - name: Install publish-release
+        uses: puerco/release-actions/setup-publish-release@9975072608f4adfb73144e8fc76603a6910f365e # main
+
+      - name: Publish Release
+        uses: puerco/release-actions/publish-release@9975072608f4adfb73144e8fc76603a6910f365e # main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        


### PR DESCRIPTION
This commit adds the [kubernetes release engineering `publish-release`](https://github.com/kubernetes/release/tree/master/cmd/publish-release) [action](https://github.com/puerco/release-actions/blob/main/publish-release/README.md) to the repo to create releases when the repo is tagged.

This will automatically create a release and SBOM the code when a new tag is pushed.

/cc @cpanato 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>