### PR TITLE
Add support for CSAF 2.0 Publisher

### DIFF
--- a/pkg/csaf/csaf.go
+++ b/pkg/csaf/csaf.go
@@ -38,6 +38,7 @@ type DocumentMetadata struct {
 	Title      string      `json:"title"`
 	Tracking   Tracking    `json:"tracking"`
 	References []Reference `json:"references"`
+	Publisher  Publisher   `json:"publisher"`
 }
 
 // Document references holds a list of references associated with the whole document.
@@ -56,6 +57,17 @@ type Tracking struct {
 	ID                 string    `json:"id"`
 	CurrentReleaseDate time.Time `json:"current_release_date"`
 	InitialReleaseDate time.Time `json:"initial_release_date"`
+}
+
+// Publisher provides information on the publishing entity.
+//
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3218-document-property---publisher
+type Publisher struct {
+	Category         string `json:"category"`
+	ContactDetails   string `json:"contact_details"`
+	IssuingAuthority string `json:"issuing_authority"`
+	Name             string `json:"name"`
+	Namespace        string `json:"namespace"`
 }
 
 // Vulnerability contains information about a CVE and its associated threats.

--- a/pkg/csaf/csaf_test.go
+++ b/pkg/csaf/csaf_test.go
@@ -34,6 +34,13 @@ func TestOpenRHAdvisory(t *testing.T) {
 	require.Equal(t, "AppStream-8.1.0.Z.MAIN.EUS", doc.FirstProductName())
 
 	require.Equal(t, "https://bugzilla.redhat.com/show_bug.cgi?id=1794290", doc.Vulnerabilities[0].IDs[0].Text)
+
+	// Publisher
+	require.Equal(t, doc.Document.Publisher.Category, "vendor")
+	require.Equal(t, doc.Document.Publisher.ContactDetails, "https://access.redhat.com/security/team/contact/")
+	require.Equal(t, doc.Document.Publisher.IssuingAuthority, "Red Hat Product Security is responsible for vulnerability handling across all Red Hat offerings.")
+	require.Equal(t, doc.Document.Publisher.Name, "Red Hat Product Security")
+	require.Equal(t, doc.Document.Publisher.Namespace, "https://www.redhat.com")
 }
 
 func TestFindFirstProduct(t *testing.T) {


### PR DESCRIPTION
- Add `publisher` type to `document` tree as defined by specifications
- Extend unit test to check `publisher`

Specifications https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3218-document-property---publisher