### PR TITLE
Update actions to kubernetes-sigs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Install publish-release
-        uses: puerco/release-actions/setup-publish-release@9975072608f4adfb73144e8fc76603a6910f365e # main
+        uses: kubernetes-sigs/release-actions/setup-publish-release@9975072608f4adfb73144e8fc76603a6910f365e # main
 
       - name: Publish Release
-        uses: puerco/release-actions/publish-release@9975072608f4adfb73144e8fc76603a6910f365e # main
+        uses: kubernetes-sigs/release-actions/publish-release@9975072608f4adfb73144e8fc76603a6910f365e # main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         


### PR DESCRIPTION
This commit updates the release actions to kubernetes-sigs now that the repo has been donated to the kubernetes organizations.

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>
