### PR TITLE
Normalize timezones in JSON output

### DIFF
--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -132,6 +132,30 @@ func (vexDoc *VEX) ToJSON(w io.Writer) error {
 	return nil
 }
 
+// MarshalJSON the document object overrides its marshaling function to normalize
+// the timezones in all dates to Zulu.
+func (vexDoc *VEX) MarshalJSON() ([]byte, error) {
+	type alias VEX
+	var ts, lu string
+
+	if vexDoc.Timestamp != nil {
+		ts = vexDoc.Timestamp.UTC().Format(time.RFC3339)
+	}
+	if vexDoc.LastUpdated != nil {
+		lu = vexDoc.LastUpdated.UTC().Format(time.RFC3339)
+	}
+
+	return json.Marshal(&struct {
+		*alias
+		TimeZonedTimestamp   string `json:"timestamp"`
+		TimeZonedLastUpdated string `json:"last_updated,omitempty"`
+	}{
+		TimeZonedTimestamp:   ts,
+		TimeZonedLastUpdated: lu,
+		alias:                (*alias)(vexDoc),
+	})
+}
+
 // EffectiveStatement returns the latest VEX statement for a given product and
 // vulnerability, that is the statement that contains the latest data about
 // impact to a given product.


### PR DESCRIPTION
This PR overrides the marshaling functions of the statement and vex.VEX object to normalize the timezones to Zulu and comply better with the [in-toto predicate guidelines](https://github.com/in-toto/attestation/blob/main/docs/new_predicate_guidelines.md):

>Timestamps SHOULD use [RFC 3339](https://tools.ietf.org/html/rfc3339) syntax with timezone "Z" and SHOULD clarify the meaning of the timestamp. For example, a field named timestamp is too ambiguous; a better name would be builtAt or allowedAt or scannedAt.

This is not a breaking change. It is just setting the timezones, no data loss or format changes are involved:

**Format Before:** 

`      "timestamp": "2023-08-15T19:55:22.076684217-06:00"`

**Format After:** (not the same date, just to contrast the TZ)

`      "timestamp": "2023-12-05T05:06:38.099731287Z"`

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>