### PR TITLE
remove deprecated action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,9 +16,6 @@ jobs:
       contents: write # needed to write releases
 
     steps:
-      - name: Install publish-release
-        uses: kubernetes-sigs/release-actions/setup-publish-release@2f8b9ec22aedc9ce15039b6c7716aa6c2907df1c # v0.2.0
-
       - name: Publish Release
         uses: kubernetes-sigs/release-actions/publish-release@2f8b9ec22aedc9ce15039b6c7716aa6c2907df1c # v0.2.0
         env:


### PR DESCRIPTION
`kubernetes-sigs/release-actions/setup-publish-release` is inside the `kubernetes-sigs/release-actions/publish-release`