### PR TITLE
Implement URL property from standard

### DIFF
--- a/pkg/csaf/csaf.go
+++ b/pkg/csaf/csaf.go
@@ -160,6 +160,7 @@ type RemediationData struct {
 	GroupIDs     []string    `json:"group_ids"`
 	ProductIDs   []string    `json:"product_ids"`
 	Restart      RestartData `json:"restart_required"`
+	Url          string      `json:"url"`
 }
 
 // Remediation instructions for restart of affected software.

--- a/pkg/csaf/csaf_test.go
+++ b/pkg/csaf/csaf_test.go
@@ -41,6 +41,9 @@ func TestOpenRHAdvisory(t *testing.T) {
 	require.Equal(t, doc.Document.Publisher.IssuingAuthority, "Red Hat Product Security is responsible for vulnerability handling across all Red Hat offerings.")
 	require.Equal(t, doc.Document.Publisher.Name, "Red Hat Product Security")
 	require.Equal(t, doc.Document.Publisher.Namespace, "https://www.redhat.com")
+
+	// Remediation Url
+	require.Equal(t, doc.Vulnerabilities[0].Remediations[0].Url, "https://access.redhat.com/errata/RHSA-2020:1358")
 }
 
 func TestFindFirstProduct(t *testing.T) {


### PR DESCRIPTION
The CSAF standard defines a URL property for remediation data. This property was missing but is actively used by Red Hat CSAF VEX to communicate the respective Red Hat Security Advisory for the vulnerability. We at Deutsche Telekom need this attribute to get this data for our internal database of security advisories.

Reference issue is: #111 
