### PR TITLE
Implementing DeepCopy and DeepCopyInto interface for VEX 

### DIFF
--- a/pkg/vex/statement.go
+++ b/pkg/vex/statement.go
@@ -231,3 +231,51 @@ func (stmt *Statement) MarshalJSON() ([]byte, error) {
 		TimeZonedLastUpdated: lu,
 	})
 }
+
+// DeepCopyInto copies the receiver and writes its value into out.
+func (stmt *Statement) DeepCopyInto(out *Statement) {
+	*out = *stmt
+
+	if stmt.Timestamp != nil {
+		*out = *stmt
+		out.Timestamp = new(time.Time)
+		*out.Timestamp = *stmt.Timestamp
+	}
+
+	if stmt.LastUpdated != nil {
+		*out = *stmt
+		out.LastUpdated = new(time.Time)
+		*out.LastUpdated = *stmt.LastUpdated
+	}
+
+	if stmt.Products != nil {
+		*out = *stmt
+		out.Products = make([]Product, len(stmt.Products))
+		copy(out.Products, stmt.Products)
+	}
+
+	*out = *stmt
+	out.Vulnerability = Vulnerability{}
+	stmt.Vulnerability.DeepCopyInto(&out.Vulnerability)
+
+	if stmt.Justification != "" {
+		*out = *stmt
+		out.Justification = stmt.Justification
+	}
+
+	if stmt.ActionStatementTimestamp != nil {
+		*out = *stmt
+		out.ActionStatementTimestamp = new(time.Time)
+		*out.ActionStatementTimestamp = *stmt.ActionStatementTimestamp
+	}
+}
+
+// DeepCopy copies the receiver and returns a new Statement.
+func (stmt *Statement) DeepCopy() *Statement {
+	if stmt == nil {
+		return nil
+	}
+	out := new(Statement)
+	stmt.DeepCopyInto(out)
+	return out
+}

--- a/pkg/vex/vulnerability.go
+++ b/pkg/vex/vulnerability.go
@@ -45,3 +45,22 @@ func (v *Vulnerability) Matches(identifier string) bool {
 	}
 	return false
 }
+
+func (v *Vulnerability) DeepCopy() *Vulnerability {
+	if v == nil {
+		return nil
+	}
+	out := &Vulnerability{}
+	v.DeepCopyInto(out)
+	return out
+}
+
+func (v *Vulnerability) DeepCopyInto(out *Vulnerability) {
+	if out == nil {
+		return
+	}
+	out.ID = v.ID
+	out.Name = v.Name
+	out.Aliases = v.Aliases
+	out.Description = v.Description
+}


### PR DESCRIPTION
This PR resumes @slashben's work on #69 (as I could not push to Ben's branch) and completes the missing DeepCopy method in the vulnerability struct. 



Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@carabiner.dev>