### PR TITLE
test: add test-cover make target and measure coverage in ci

### DIFF
--- a/.github/workflows/ci-build-test.yaml
+++ b/.github/workflows/ci-build-test.yaml
@@ -40,4 +40,4 @@ jobs:
           cache: true
 
       - name: test
-        run: make test
+        run: make test-cover

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,8 @@ build: pkg
 .PHONY: test
 test:
 	go test -v ./...
+
+.PHONY: test-cover
+test-cover:
+	go test -v -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out -o coverage.html

--- a/pkg/attestation/attestation_test.go
+++ b/pkg/attestation/attestation_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openvex/go-vex/pkg/vex"
@@ -29,4 +30,36 @@ func TestSerialize(t *testing.T) {
 	err = json.Unmarshal(b.Bytes(), &att2)
 	require.NoError(t, err)
 	require.Equal(t, att2.Predicate.Author, "Chainguard")
+}
+
+func TestAddSubjects(t *testing.T) {
+	att := New()
+
+	// Test adding valid subjects
+	validSubs := []intoto.Subject{
+		{
+			Name:   "test1",
+			Digest: map[string]string{"sha256": "abc123"},
+		},
+		{
+			Name:   "test2",
+			Digest: map[string]string{"sha256": "def456"},
+		},
+	}
+	err := att.AddSubjects(validSubs)
+	require.NoError(t, err)
+	require.Len(t, att.Subject, 2)
+	require.Equal(t, validSubs[0], att.Subject[0])
+	require.Equal(t, validSubs[1], att.Subject[1])
+
+	// Test adding subject with no digest
+	invalidSubs := []intoto.Subject{
+		{
+			Name: "test3",
+		},
+	}
+	err = att.AddSubjects(invalidSubs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "subject test3 has no digests")
+	require.Len(t, att.Subject, 2) // Length should not change
 }


### PR DESCRIPTION
This PR makes the following changes:
 * adds a new make target `test-cover` that executes the go tests and measures and reports on test coverage
 * updates the CI workflow that previously ran `make test` to run `make test-cover` to provide feedback on changes to test coverage
 * adds test coverage for Attestation#AddSubjects as `make test-cover` showed it as uncovered