### PR TITLE
fix: support CSAF.Vulnerability.RemediationData.URL

### DIFF
--- a/pkg/csaf/csaf.go
+++ b/pkg/csaf/csaf.go
@@ -163,6 +163,7 @@ type RemediationData struct {
 	GroupIDs     []string    `json:"group_ids"`
 	ProductIDs   []string    `json:"product_ids"`
 	Restart      RestartData `json:"restart_required"`
+	URL          string      `json:"url"`
 }
 
 // Remediation instructions for restart of affected software.

--- a/pkg/csaf/csaf_test.go
+++ b/pkg/csaf/csaf_test.go
@@ -17,11 +17,11 @@ func TestOpen(t *testing.T) {
 	require.Equal(t, "CSAFPID-0001", doc.FirstProductName())
 
 	// Vulnerabilities
-	require.Len(t, doc.Vulnerabilities, 1)
+	require.Len(t, doc.Vulnerabilities, 2)
 	require.Equal(t, "CVE-2009-4487", doc.Vulnerabilities[0].CVE)
-	require.Len(t, doc.Vulnerabilities[0].ProductStatus, 2)
-	require.Len(t, doc.Vulnerabilities[0].ProductStatus["known_not_affected"], 1)
 	require.Equal(t, "CSAFPID-0001", doc.Vulnerabilities[0].ProductStatus["known_not_affected"][0])
+	require.Equal(t, "CVE-2009-4488", doc.Vulnerabilities[1].CVE)
+	require.Equal(t, "https://example.com/foo/v1.2.3/mitigation", doc.Vulnerabilities[1].Remediations[0].URL)
 }
 
 func TestOpenRHAdvisory(t *testing.T) {

--- a/pkg/csaf/testdata/csaf.json
+++ b/pkg/csaf/testdata/csaf.json
@@ -120,6 +120,43 @@
           ]
         }
       ]
+    },
+    {
+      "cve": "CVE-2009-4488",
+      "notes": [
+        {
+          "category": "description",
+          "text": "Example software foo v1.2.3 has denial of service vulnerability",
+          "title": "CVE description"
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "CSAFPID-0001"
+        ],
+        "known_affected": [
+          "ABC:CSAFPID-0002"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "mitigation",
+          "details": "Configure a reverse proxy to limit the size of POST request bodies to 1000 bytes before forwarding them to the vulnerable application.",
+          "product_ids": [
+            "CSAFPID-0001"
+          ],
+          "url": "https://example.com/foo/v1.2.3/mitigation"
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Class with vulnerable code was removed before shipping.",
+          "product_ids": [
+            "CSAFPID-0001"
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR closes https://github.com/openvex/go-vex/issues/111 by adding the struct field `URL` to `RemediationData` and adding test coverage of the change.