### PR TITLE
Bump go to 1.24.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openvex/go-vex
 
-go 1.22
+go 1.24.8
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
This bumps the minimal go version to 1.24.8 to fix two security advisories 

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@carabiner.dev>