### PR TITLE
Expand CSAF schema support

### DIFF
--- a/pkg/attestation/attestation_test.go
+++ b/pkg/attestation/attestation_test.go
@@ -23,7 +23,7 @@ func newTestVEX() vex.VEX {
 		Metadata: vex.Metadata{
 			Context:   vex.ContextLocator(),
 			ID:        "https://openvex.dev/docs/test/vex-001",
-			Author:    "mailto:test@example.com",
+			Author:    testAuthorEmail,
 			Timestamp: &ts,
 			Version:   1,
 		},
@@ -35,7 +35,7 @@ func newTestVEX() vex.VEX {
 				Products: []vex.Product{
 					{
 						Component: vex.Component{
-							ID: "pkg:oci/nginx@sha256:abc123",
+							ID: testOCINginxPURL,
 						},
 					},
 				},
@@ -67,7 +67,7 @@ func TestPredicateGetData(t *testing.T) {
 	// Verify the author round-trips correctly
 	var author string
 	require.NoError(t, json.Unmarshal(parsed["author"], &author))
-	require.Equal(t, "mailto:test@example.com", author)
+	require.Equal(t, testAuthorEmail, author)
 }
 
 func TestPredicateGetDataNilDoc(t *testing.T) {
@@ -112,8 +112,8 @@ func TestAttestationMarshalJSON(t *testing.T) {
 	}
 	require.NoError(t, att.AddSubjects([]*intoto.ResourceDescriptor{
 		{
-			Name:   "pkg:oci/nginx@sha256:abc123",
-			Digest: map[string]string{"sha256": "abc123def456"},
+			Name:   testOCINginxPURL,
+			Digest: map[string]string{testSHA256: testDigestABC123Def456},
 		},
 	}))
 
@@ -146,11 +146,11 @@ func TestAttestationMarshalJSON(t *testing.T) {
 
 	var name string
 	require.NoError(t, json.Unmarshal(subjects[0]["name"], &name))
-	require.Equal(t, "pkg:oci/nginx@sha256:abc123", name)
+	require.Equal(t, testOCINginxPURL, name)
 
 	var digest map[string]string
 	require.NoError(t, json.Unmarshal(subjects[0]["digest"], &digest))
-	require.Equal(t, "abc123def456", digest["sha256"])
+	require.Equal(t, testDigestABC123Def456, digest[testSHA256])
 
 	// predicate must contain the VEX document
 	var predicate map[string]json.RawMessage
@@ -160,7 +160,7 @@ func TestAttestationMarshalJSON(t *testing.T) {
 
 	var author string
 	require.NoError(t, json.Unmarshal(predicate["author"], &author))
-	require.Equal(t, "mailto:test@example.com", author)
+	require.Equal(t, testAuthorEmail, author)
 }
 
 func TestAttestationMarshalNoProtobufFieldNames(t *testing.T) {
@@ -188,8 +188,8 @@ func TestAttestationToJSON(t *testing.T) {
 	}
 	require.NoError(t, att.AddSubjects([]*intoto.ResourceDescriptor{
 		{
-			Name:   "pkg:oci/nginx@sha256:abc123",
-			Digest: map[string]string{"sha256": "abc123def456"},
+			Name:   testOCINginxPURL,
+			Digest: map[string]string{testSHA256: testDigestABC123Def456},
 		},
 	}))
 
@@ -216,7 +216,7 @@ func TestAttestationRoundTrip(t *testing.T) {
 	require.NoError(t, att.AddSubjects([]*intoto.ResourceDescriptor{
 		{
 			Name:   "test-subject",
-			Digest: map[string]string{"sha256": "deadbeef"},
+			Digest: map[string]string{testSHA256: "deadbeef"},
 		},
 	}))
 
@@ -247,11 +247,11 @@ func TestAttestationMultipleSubjects(t *testing.T) {
 	require.NoError(t, att.AddSubjects([]*intoto.ResourceDescriptor{
 		{
 			Name:   "pkg:oci/app@sha256:aaa",
-			Digest: map[string]string{"sha256": "aaa"},
+			Digest: map[string]string{testSHA256: "aaa"},
 		},
 		{
 			Name:   "pkg:oci/app@sha256:bbb",
-			Digest: map[string]string{"sha256": "bbb"},
+			Digest: map[string]string{testSHA256: "bbb"},
 		},
 	}))
 
@@ -289,21 +289,21 @@ func TestNewWithPredicate(t *testing.T) {
 	require.NoError(t, json.Unmarshal(envelope["predicate"], &predicate))
 	var author string
 	require.NoError(t, json.Unmarshal(predicate["author"], &author))
-	require.Equal(t, "mailto:test@example.com", author)
+	require.Equal(t, testAuthorEmail, author)
 }
 
 func TestNewWithSubjects(t *testing.T) {
 	s1 := &intoto.ResourceDescriptor{
 		Name:   "pkg:oci/app@sha256:aaa",
-		Digest: map[string]string{"sha256": "aaa"},
+		Digest: map[string]string{testSHA256: "aaa"},
 	}
 	s2 := &intoto.ResourceDescriptor{
 		Name:   "pkg:oci/app@sha256:bbb",
-		Digest: map[string]string{"sha256": "bbb"},
+		Digest: map[string]string{testSHA256: "bbb"},
 	}
 	s3 := &intoto.ResourceDescriptor{
 		Name:   "pkg:oci/app@sha256:ccc",
-		Digest: map[string]string{"sha256": "ccc"},
+		Digest: map[string]string{testSHA256: "ccc"},
 	}
 
 	// Variadic in a single call plus a second WithSubjects call must accumulate.
@@ -322,8 +322,8 @@ func TestNewWithPredicateAndSubjects(t *testing.T) {
 	att := New(
 		WithPredicate(&doc),
 		WithSubjects(&intoto.ResourceDescriptor{
-			Name:   "pkg:oci/nginx@sha256:abc123",
-			Digest: map[string]string{"sha256": "abc123def456"},
+			Name:   testOCINginxPURL,
+			Digest: map[string]string{testSHA256: testDigestABC123Def456},
 		}),
 		WithImportProducts(false),
 	)
@@ -382,11 +382,11 @@ func TestAddSubjects(t *testing.T) {
 	validSubs := []*intoto.ResourceDescriptor{
 		{
 			Name:   "test1",
-			Digest: map[string]string{"sha256": "abc123"},
+			Digest: map[string]string{testSHA256: "abc123"},
 		},
 		{
 			Name:   "test2",
-			Digest: map[string]string{"sha256": "def456"},
+			Digest: map[string]string{testSHA256: "def456"},
 		},
 	}
 

--- a/pkg/attestation/subjects_test.go
+++ b/pkg/attestation/subjects_test.go
@@ -30,7 +30,7 @@ func vexWithProducts(prods ...vex.Product) vex.VEX {
 		Metadata: vex.Metadata{
 			Context:   vex.ContextLocator(),
 			ID:        "https://openvex.dev/docs/test/import",
-			Author:    "mailto:test@example.com",
+			Author:    testAuthorEmail,
 			Timestamp: &ts,
 			Version:   1,
 		},
@@ -57,7 +57,7 @@ func TestImportOCIPurlWithEmbeddedDigest(t *testing.T) {
 	s := att.Subject[0]
 	require.Equal(t, purl, s.GetUri(), "original purl must be in Uri")
 	require.Equal(t, "nginx@sha256:abc123def456", s.GetName(), "image ref must be in Name")
-	require.Equal(t, map[string]string{"sha256": "abc123def456"}, s.GetDigest())
+	require.Equal(t, map[string]string{testSHA256: testDigestABC123Def456}, s.GetDigest())
 }
 
 func TestImportOCIPurlWithRepositoryURLAndTag(t *testing.T) {
@@ -75,11 +75,11 @@ func TestImportOCIPurlWithRepositoryURLAndTag(t *testing.T) {
 	s := att.Subject[0]
 	require.Equal(t, purl, s.GetUri())
 	require.Equal(t, "ghcr.io/myorg/app:1.2.3", s.GetName())
-	require.Equal(t, map[string]string{"sha256": "cafebabe"}, s.GetDigest())
+	require.Equal(t, map[string]string{testSHA256: "cafebabe"}, s.GetDigest())
 }
 
 func TestImportOCIPurlFromIdentifiers(t *testing.T) {
-	ociPurl := "pkg:oci/nginx@sha256:abc123"
+	ociPurl := testOCINginxPURL
 	doc := vexWithProducts(vex.Product{
 		Component: vex.Component{
 			ID: "https://example.com/some-iri",
@@ -144,7 +144,7 @@ func TestImportNonOCIWithHashes(t *testing.T) {
 	require.Len(t, att.Subject, 1)
 	s := att.Subject[0]
 	require.Equal(t, "pkg:npm/lodash@4.17.21", s.GetName())
-	require.Equal(t, "deadbeef", s.GetDigest()["sha256"], "vex.SHA256 must map to in-toto sha256")
+	require.Equal(t, "deadbeef", s.GetDigest()[testSHA256], "vex.SHA256 must map to in-toto sha256")
 	require.Equal(t, "feedface", s.GetDigest()["sha512"], "vex.SHA512 must map to in-toto sha512")
 }
 
@@ -171,7 +171,7 @@ func TestImportDropsUnmappableAlgorithm(t *testing.T) {
 func TestImportDefaultsOn(t *testing.T) {
 	resolver := ImageDigestResolver(func(string) (string, error) { return "sha256:aaa", nil })
 	doc := vexWithProducts(vex.Product{
-		Component: vex.Component{ID: "pkg:oci/app"},
+		Component: vex.Component{ID: testOCIAppPURL},
 	})
 	// No WithImportProducts option — default should import.
 	att := New(WithPredicate(&doc), WithImageDigestResolver(resolver))
@@ -207,7 +207,7 @@ func TestImportDedupesAcrossStatements(t *testing.T) {
 		Metadata: vex.Metadata{
 			Context:   vex.ContextLocator(),
 			ID:        "https://openvex.dev/docs/test/dup",
-			Author:    "mailto:test@example.com",
+			Author:    testAuthorEmail,
 			Timestamp: &ts,
 			Version:   1,
 		},
@@ -223,7 +223,7 @@ func TestNewWithErrorPropagatesResolverFailure(t *testing.T) {
 		return "", errors.New("registry unreachable")
 	})
 	doc := vexWithProducts(vex.Product{
-		Component: vex.Component{ID: "pkg:oci/app"},
+		Component: vex.Component{ID: testOCIAppPURL},
 	})
 
 	att, err := NewWithError(WithPredicate(&doc), WithImageDigestResolver(resolver))
@@ -245,7 +245,7 @@ func TestNewBestEffortSkipsOnResolverFailure(t *testing.T) {
 		Metadata: vex.Metadata{
 			Context:   vex.ContextLocator(),
 			ID:        "https://openvex.dev/docs/test/skip",
-			Author:    "mailto:test@example.com",
+			Author:    testAuthorEmail,
 			Timestamp: &ts,
 			Version:   1,
 		},
@@ -270,12 +270,12 @@ func TestNewBestEffortSkipsOnResolverFailure(t *testing.T) {
 func TestImportPreservesExplicitSubjects(t *testing.T) {
 	resolver := ImageDigestResolver(func(string) (string, error) { return "sha256:imported", nil })
 	doc := vexWithProducts(vex.Product{
-		Component: vex.Component{ID: "pkg:oci/app"},
+		Component: vex.Component{ID: testOCIAppPURL},
 	})
 
 	explicit := &intoto.ResourceDescriptor{
 		Name:   "manually-added",
-		Digest: map[string]string{"sha256": "manual"},
+		Digest: map[string]string{testSHA256: "manual"},
 	}
 	att := New(
 		WithPredicate(&doc),
@@ -291,7 +291,7 @@ func TestImportNoResolverNoDigestStrictErrors(t *testing.T) {
 	// OCI purl without an embedded digest and no resolver configured:
 	// NewWithError must surface errNoResolver.
 	doc := vexWithProducts(vex.Product{
-		Component: vex.Component{ID: "pkg:oci/app"},
+		Component: vex.Component{ID: testOCIAppPURL},
 	})
 
 	att, err := NewWithError(WithPredicate(&doc))
@@ -302,7 +302,7 @@ func TestImportNoResolverNoDigestStrictErrors(t *testing.T) {
 func TestImportNoResolverNoDigestBestEffortSkips(t *testing.T) {
 	// Best-effort New must skip the unresolvable product rather than error.
 	doc := vexWithProducts(
-		vex.Product{Component: vex.Component{ID: "pkg:oci/app"}},
+		vex.Product{Component: vex.Component{ID: testOCIAppPURL}},
 		vex.Product{Component: vex.Component{ID: "pkg:oci/good@sha256:abc"}},
 	)
 

--- a/pkg/attestation/test_constants_test.go
+++ b/pkg/attestation/test_constants_test.go
@@ -1,0 +1,12 @@
+// Copyright 2026 The OpenVEX Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package attestation
+
+const (
+	testAuthorEmail        = "mailto:test@example.com"
+	testDigestABC123Def456 = "abc123def456"
+	testSHA256             = "sha256"
+	testOCIAppPURL         = "pkg:oci/app"
+	testOCINginxPURL       = "pkg:oci/nginx@sha256:abc123"
+)

--- a/pkg/csaf/csaf.go
+++ b/pkg/csaf/csaf.go
@@ -40,13 +40,14 @@ type CSAF struct {
 //
 // https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#321-document-property
 type DocumentMetadata struct {
-	Category    string      `json:"category,omitempty"`
-	CSAFVersion string      `json:"csaf_version,omitempty"`
-	Notes       []Note      `json:"notes,omitempty"`
-	Title       string      `json:"title"`
-	Tracking    Tracking    `json:"tracking"`
-	References  []Reference `json:"references,omitempty"`
-	Publisher   Publisher   `json:"publisher"`
+	Category     string         `json:"category,omitempty"`
+	CSAFVersion  string         `json:"csaf_version,omitempty"`
+	Distribution map[string]any `json:"distribution,omitempty"`
+	Notes        []Note         `json:"notes,omitempty"`
+	Title        string         `json:"title"`
+	Tracking     Tracking       `json:"tracking"`
+	References   []Reference    `json:"references,omitempty"`
+	Publisher    Publisher      `json:"publisher"`
 }
 
 // Document references holds a list of references associated with the whole document.
@@ -114,6 +115,9 @@ type Vulnerability struct {
 	//
 	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3232-vulnerabilities-property---cve
 	CVE string `json:"cve"`
+
+	// Title gives the document producer's canonical name for the vulnerability.
+	Title string `json:"title,omitempty"`
 
 	// List of IDs represents a list of unique labels or tracking IDs for the vulnerability (if such information exists).
 	//

--- a/pkg/csaf/csaf.go
+++ b/pkg/csaf/csaf.go
@@ -6,6 +6,7 @@ package csaf
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"time"
 )
@@ -32,17 +33,20 @@ type CSAF struct {
 
 	// Notes holds notes associated with the whole document.
 	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3217-document-property---notes
-	Notes []Note `json:"notes"`
+	Notes []Note `json:"notes,omitempty"`
 }
 
 // DocumentMetadata contains metadata about the CSAF document itself.
 //
 // https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#321-document-property
 type DocumentMetadata struct {
-	Title      string      `json:"title"`
-	Tracking   Tracking    `json:"tracking"`
-	References []Reference `json:"references"`
-	Publisher  Publisher   `json:"publisher"`
+	Category    string      `json:"category,omitempty"`
+	CSAFVersion string      `json:"csaf_version,omitempty"`
+	Notes       []Note      `json:"notes,omitempty"`
+	Title       string      `json:"title"`
+	Tracking    Tracking    `json:"tracking"`
+	References  []Reference `json:"references,omitempty"`
+	Publisher   Publisher   `json:"publisher"`
 }
 
 // Document references holds a list of references associated with the whole document.
@@ -58,9 +62,37 @@ type Reference struct {
 //
 // https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#32112-document-property---tracking
 type Tracking struct {
-	ID                 string    `json:"id"`
-	CurrentReleaseDate time.Time `json:"current_release_date"`
-	InitialReleaseDate time.Time `json:"initial_release_date"`
+	ID                 string     `json:"id"`
+	CurrentReleaseDate time.Time  `json:"current_release_date"`
+	InitialReleaseDate time.Time  `json:"initial_release_date"`
+	RevisionHistory    []Revision `json:"revision_history,omitempty"`
+	Status             string     `json:"status,omitempty"`
+	Version            string     `json:"version,omitempty"`
+	Generator          Generator  `json:"generator,omitempty,omitzero"`
+}
+
+// Revision contains information needed to track a document revision.
+//
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#321126-revision-history-type---revision
+type Revision struct {
+	Date          time.Time `json:"date"`
+	LegacyVersion string    `json:"legacy_version,omitempty"`
+	Number        string    `json:"number"`
+	Summary       string    `json:"summary"`
+}
+
+// Generator holds information about how the CSAF document was generated.
+//
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#321123-document-property---tracking---generator
+type Generator struct {
+	Date   time.Time `json:"date,omitempty,omitzero"`
+	Engine Engine    `json:"engine"`
+}
+
+// Engine identifies the generator engine.
+type Engine struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
 }
 
 // Publisher provides information on the publishing entity.
@@ -68,8 +100,8 @@ type Tracking struct {
 // https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3218-document-property---publisher
 type Publisher struct {
 	Category         string `json:"category"`
-	ContactDetails   string `json:"contact_details"`
-	IssuingAuthority string `json:"issuing_authority"`
+	ContactDetails   string `json:"contact_details,omitempty"`
+	IssuingAuthority string `json:"issuing_authority,omitempty"`
 	Name             string `json:"name"`
 	Namespace        string `json:"namespace"`
 }
@@ -86,50 +118,50 @@ type Vulnerability struct {
 	// List of IDs represents a list of unique labels or tracking IDs for the vulnerability (if such information exists).
 	//
 	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3236-vulnerabilities-property---ids
-	IDs []TrackingID `json:"ids"`
+	IDs []TrackingID `json:"ids,omitempty"`
 
 	// Provide details on the status of the referenced product related to the vulnerability.
 	//
 	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3239-vulnerabilities-property---product-status
-	ProductStatus map[string][]string `json:"product_status"`
+	ProductStatus ProductStatus `json:"product_status,omitempty"`
 
 	// Provide details of threats associated with a vulnerability.
 	//
 	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#32314-vulnerabilities-property---threats
-	Threats []ThreatData `json:"threats"`
+	Threats []ThreatData `json:"threats,omitempty"`
 
 	// Provide details of remediations associated with a Vulnerability
 	//
 	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#32312-vulnerabilities-property---remediations
-	Remediations []RemediationData `json:"remediations"`
+	Remediations []RemediationData `json:"remediations,omitempty"`
 
 	// Machine readable flags for products related to vulnerability
 	//
 	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3235-vulnerabilities-property---flags
-	Flags []Flag `json:"flags"`
+	Flags []Flag `json:"flags,omitempty"`
 
 	// Vulnerability references holds a list of references associated with this vulnerability item.
 	//
 	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#32310-vulnerabilities-property---references
-	References []Reference `json:"references"`
+	References []Reference `json:"references,omitempty"`
 
-	ReleaseDate time.Time `json:"release_date"`
+	ReleaseDate time.Time `json:"release_date,omitempty,omitzero"`
 
 	// Notes holds notes associated with the Vulnerability object.
 	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3238-vulnerabilities-property---notes
-	Notes []Note `json:"notes"`
+	Notes []Note `json:"notes,omitempty"`
 
 	// Scores holds the scores associated with the Vulnerability object.
 	// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#32313-vulnerabilities-property---scores
 	// Currently only CVSS v3 is supported.
-	Scores []Score `json:"scores"`
+	Scores []Score `json:"scores,omitempty"`
 }
 
 type Note struct {
 	Category string `json:"category"`
 	Text     string `json:"text"`
-	Title    string `json:"title"`
-	Audience string `json:"audience"`
+	Title    string `json:"title,omitempty"`
+	Audience string `json:"audience,omitempty"`
 }
 
 // Every ID item with the two mandatory properties System Name (system_name) and Text (text) contains a single unique label or tracking ID for the vulnerability.
@@ -154,13 +186,13 @@ type ThreatData struct {
 // https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#32312-vulnerabilities-property---remediations
 type RemediationData struct {
 	Category     string      `json:"category"`
-	Date         time.Time   `json:"date"`
+	Date         time.Time   `json:"date,omitempty,omitzero"`
 	Details      string      `json:"details"`
-	Entitlements []string    `json:"entitlements"`
-	GroupIDs     []string    `json:"group_ids"`
-	ProductIDs   []string    `json:"product_ids"`
-	Restart      RestartData `json:"restart_required"`
-	URL          string      `json:"url"`
+	Entitlements []string    `json:"entitlements,omitempty"`
+	GroupIDs     []string    `json:"group_ids,omitempty"`
+	ProductIDs   []string    `json:"product_ids,omitempty"`
+	Restart      RestartData `json:"restart_required,omitempty,omitzero"`
+	URL          string      `json:"url,omitempty"`
 }
 
 // Remediation instructions for restart of affected software.
@@ -168,7 +200,7 @@ type RemediationData struct {
 // https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#323127-vulnerabilities-property---remediations---restart-required
 type RestartData struct {
 	Category string `json:"category"`
-	Details  string `json:"details"`
+	Details  string `json:"details,omitempty"`
 }
 
 // Machine readable flags for products related to the Vulnerability
@@ -176,9 +208,9 @@ type RestartData struct {
 // https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3235-vulnerabilities-property---flags
 type Flag struct {
 	Label      string    `json:"label"`
-	Date       time.Time `json:"date"`
-	GroupIDs   []string  `json:"group_ids"`
-	ProductIDs []string  `json:"product_ids"`
+	Date       time.Time `json:"date,omitempty,omitzero"`
+	GroupIDs   []string  `json:"group_ids,omitempty"`
+	ProductIDs []string  `json:"product_ids,omitempty"`
 }
 
 // ProductBranch is a recursive struct that contains information about a product and
@@ -186,11 +218,11 @@ type Flag struct {
 //
 // https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3221-product-tree-property---branches
 type ProductBranch struct {
-	Category      string          `json:"category"`
-	Name          string          `json:"name"`
-	Branches      []ProductBranch `json:"branches"`
-	Product       Product         `json:"product,omitempty"`
-	Relationships []Relationship  `json:"relationships"`
+	Category      string          `json:"category,omitempty"`
+	Name          string          `json:"name,omitempty"`
+	Branches      []ProductBranch `json:"branches,omitempty"`
+	Product       Product         `json:"product,omitempty,omitzero"`
+	Relationships []Relationship  `json:"relationships,omitempty"`
 }
 
 // Relationship establishes a link between two existing full_product_name_t elements, allowing
@@ -210,7 +242,7 @@ type Relationship struct {
 type Product struct {
 	Name                 string            `json:"name"`
 	ID                   string            `json:"product_id"`
-	IdentificationHelper map[string]string `json:"product_identification_helper"`
+	IdentificationHelper map[string]string `json:"product_identification_helper,omitempty"`
 }
 
 // Score contains score information tied to the listed products.
@@ -278,6 +310,29 @@ func Open(path string) (*CSAF, error) {
 	}
 
 	return csafDoc, nil
+}
+
+// ToJSON serializes the CSAF document to JSON and writes it to the passed writer.
+func (csafDoc *CSAF) ToJSON(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+
+	if err := enc.Encode(csafDoc); err != nil {
+		return fmt.Errorf("encoding csaf document: %w", err)
+	}
+	return nil
+}
+
+// ValidateProductStatuses verifies that all vulnerability product_status
+// buckets use CSAF-defined status names.
+func (csafDoc *CSAF) ValidateProductStatuses() error {
+	for i := range csafDoc.Vulnerabilities {
+		if err := csafDoc.Vulnerabilities[i].ProductStatus.Validate(); err != nil {
+			return fmt.Errorf("vulnerabilities[%d].product_status: %w", i, err)
+		}
+	}
+	return nil
 }
 
 // FirstProductName returns the first product name in the product tree

--- a/pkg/csaf/csaf_test.go
+++ b/pkg/csaf/csaf_test.go
@@ -6,6 +6,8 @@ package csaf
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -81,6 +83,42 @@ func TestToJSONPreservesModeledCSAFFields(t *testing.T) {
 	vulnerabilities := roundTrip["vulnerabilities"].([]any)
 	vulnerability := vulnerabilities[0].(map[string]any)
 	require.Equal(t, "Example vulnerability", vulnerability["title"])
+}
+
+func TestGoldenCSAFRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	inputPath := filepath.Join("testdata", "product-statuses.json")
+	inputData, err := os.ReadFile(inputPath)
+	require.NoError(t, err)
+
+	doc, err := Open(inputPath)
+	require.NoError(t, err)
+	require.NoError(t, doc.ValidateProductStatuses())
+
+	require.Equal(t, "csaf_vex", doc.Document.Category)
+	require.Equal(t, "2.0", doc.Document.CSAFVersion)
+	require.Equal(t, "WHITE", doc.Document.Distribution["tlp"].(map[string]any)["label"])
+	require.Equal(t, "go-vex-test", doc.Document.Tracking.Generator.Engine.Name)
+	require.Equal(t, "Example vulnerability covering CSAF product statuses", doc.Vulnerabilities[0].Title)
+
+	for _, status := range ProductStatusNames() {
+		require.NotEmpty(t, doc.Vulnerabilities[0].ProductStatus[status], status)
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "product-statuses.json")
+	fh, err := os.Create(outputPath)
+	require.NoError(t, err)
+	require.NoError(t, doc.ToJSON(fh))
+	require.NoError(t, fh.Close())
+
+	roundTrip, err := Open(outputPath)
+	require.NoError(t, err)
+	require.NoError(t, roundTrip.ValidateProductStatuses())
+
+	outputData, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	require.JSONEq(t, string(inputData), string(outputData))
 }
 
 func TestOpenRHAdvisory(t *testing.T) {

--- a/pkg/csaf/csaf_test.go
+++ b/pkg/csaf/csaf_test.go
@@ -4,6 +4,8 @@
 package csaf
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,6 +24,63 @@ func TestOpen(t *testing.T) {
 	require.Equal(t, "CSAFPID-0001", doc.Vulnerabilities[0].ProductStatus["known_not_affected"][0])
 	require.Equal(t, "CVE-2009-4488", doc.Vulnerabilities[1].CVE)
 	require.Equal(t, "https://example.com/foo/v1.2.3/mitigation", doc.Vulnerabilities[1].Remediations[0].URL)
+}
+
+func TestToJSONPreservesModeledCSAFFields(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+	  "document": {
+	    "category": "csaf_vex",
+	    "csaf_version": "2.0",
+	    "distribution": {
+	      "tlp": {
+	        "label": "WHITE"
+	      }
+	    },
+	    "publisher": {
+	      "category": "vendor",
+	      "name": "Example Company",
+	      "namespace": "https://psirt.example.com"
+	    },
+	    "title": "Example VEX Document",
+	    "tracking": {
+	      "current_release_date": "2026-05-26T00:00:00Z",
+	      "id": "EXAMPLE-2026-001",
+	      "initial_release_date": "2026-05-26T00:00:00Z"
+	    }
+	  },
+	  "product_tree": {},
+	  "vulnerabilities": [
+	    {
+	      "cve": "CVE-2026-46598",
+	      "title": "Example vulnerability",
+	      "product_status": {
+	        "last_affected": [
+	          "CSAFPID-0001"
+	        ]
+	      }
+	    }
+	  ]
+	}`)
+
+	doc := &CSAF{}
+	require.NoError(t, json.Unmarshal(data, doc))
+
+	var output bytes.Buffer
+	require.NoError(t, doc.ToJSON(&output))
+
+	roundTrip := map[string]any{}
+	require.NoError(t, json.Unmarshal(output.Bytes(), &roundTrip))
+
+	document := roundTrip["document"].(map[string]any)
+	distribution := document["distribution"].(map[string]any)
+	tlp := distribution["tlp"].(map[string]any)
+	require.Equal(t, "WHITE", tlp["label"])
+
+	vulnerabilities := roundTrip["vulnerabilities"].([]any)
+	vulnerability := vulnerabilities[0].(map[string]any)
+	require.Equal(t, "Example vulnerability", vulnerability["title"])
 }
 
 func TestOpenRHAdvisory(t *testing.T) {

--- a/pkg/csaf/csaf_test.go
+++ b/pkg/csaf/csaf_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -71,34 +70,24 @@ func TestToJSONPreservesModeledCSAFFields(t *testing.T) {
 
 	var output bytes.Buffer
 	require.NoError(t, doc.ToJSON(&output))
-
-	roundTrip := map[string]any{}
-	require.NoError(t, json.Unmarshal(output.Bytes(), &roundTrip))
-
-	document := roundTrip["document"].(map[string]any)
-	distribution := document["distribution"].(map[string]any)
-	tlp := distribution["tlp"].(map[string]any)
-	require.Equal(t, "WHITE", tlp["label"])
-
-	vulnerabilities := roundTrip["vulnerabilities"].([]any)
-	vulnerability := vulnerabilities[0].(map[string]any)
-	require.Equal(t, "Example vulnerability", vulnerability["title"])
+	require.JSONEq(t, string(data), output.String())
 }
 
 func TestGoldenCSAFRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	inputPath := filepath.Join("testdata", "product-statuses.json")
-	inputData, err := os.ReadFile(inputPath)
+	inputData, err := os.ReadFile("testdata/product-statuses.json")
 	require.NoError(t, err)
 
-	doc, err := Open(inputPath)
+	doc, err := Open("testdata/product-statuses.json")
 	require.NoError(t, err)
 	require.NoError(t, doc.ValidateProductStatuses())
 
 	require.Equal(t, "csaf_vex", doc.Document.Category)
 	require.Equal(t, "2.0", doc.Document.CSAFVersion)
-	require.Equal(t, "WHITE", doc.Document.Distribution["tlp"].(map[string]any)["label"])
+	tlp, ok := doc.Document.Distribution["tlp"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "WHITE", tlp["label"])
 	require.Equal(t, "go-vex-test", doc.Document.Tracking.Generator.Engine.Name)
 	require.Equal(t, "Example vulnerability covering CSAF product statuses", doc.Vulnerabilities[0].Title)
 
@@ -106,19 +95,14 @@ func TestGoldenCSAFRoundTrip(t *testing.T) {
 		require.NotEmpty(t, doc.Vulnerabilities[0].ProductStatus[status], status)
 	}
 
-	outputPath := filepath.Join(t.TempDir(), "product-statuses.json")
-	fh, err := os.Create(outputPath)
-	require.NoError(t, err)
-	require.NoError(t, doc.ToJSON(fh))
-	require.NoError(t, fh.Close())
+	var output bytes.Buffer
+	require.NoError(t, doc.ToJSON(&output))
 
-	roundTrip, err := Open(outputPath)
-	require.NoError(t, err)
+	roundTrip := &CSAF{}
+	require.NoError(t, json.Unmarshal(output.Bytes(), roundTrip))
 	require.NoError(t, roundTrip.ValidateProductStatuses())
 
-	outputData, err := os.ReadFile(outputPath)
-	require.NoError(t, err)
-	require.JSONEq(t, string(inputData), string(outputData))
+	require.JSONEq(t, string(inputData), output.String())
 }
 
 func TestOpenRHAdvisory(t *testing.T) {

--- a/pkg/csaf/product_status.go
+++ b/pkg/csaf/product_status.go
@@ -1,0 +1,92 @@
+// Copyright 2023 The OpenVEX Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package csaf
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ProductStatusName identifies one of the CSAF product_status buckets.
+type ProductStatusName string
+
+const (
+	ProductStatusFirstAffected      = "first_affected"
+	ProductStatusFirstFixed         = "first_fixed"
+	ProductStatusFixed              = "fixed"
+	ProductStatusKnownAffected      = "known_affected"
+	ProductStatusKnownNotAffected   = "known_not_affected"
+	ProductStatusLastAffected       = "last_affected"
+	ProductStatusRecommended        = "recommended"
+	ProductStatusUnderInvestigation = "under_investigation"
+)
+
+// ProductStatus contains CSAF product status buckets keyed by status name.
+type ProductStatus map[string][]string
+
+// ProductStatusNames returns the CSAF product status names defined by the
+// schema in a stable order.
+func ProductStatusNames() []string {
+	return []string{
+		string(ProductStatusFirstAffected),
+		string(ProductStatusFirstFixed),
+		string(ProductStatusFixed),
+		string(ProductStatusKnownAffected),
+		string(ProductStatusKnownNotAffected),
+		string(ProductStatusLastAffected),
+		string(ProductStatusRecommended),
+		string(ProductStatusUnderInvestigation),
+	}
+}
+
+// Valid reports whether the product status name is defined by CSAF.
+func (status ProductStatusName) Valid() bool {
+	switch status {
+	case ProductStatusFirstAffected,
+		ProductStatusFirstFixed,
+		ProductStatusFixed,
+		ProductStatusKnownAffected,
+		ProductStatusKnownNotAffected,
+		ProductStatusLastAffected,
+		ProductStatusRecommended,
+		ProductStatusUnderInvestigation:
+		return true
+	default:
+		return false
+	}
+}
+
+// Affected reports whether the CSAF status denotes an affected product.
+func (status ProductStatusName) Affected() bool {
+	switch status {
+	case ProductStatusFirstAffected,
+		ProductStatusKnownAffected,
+		ProductStatusLastAffected:
+		return true
+	default:
+		return false
+	}
+}
+
+// Fixed reports whether the CSAF status denotes a fixed product.
+func (status ProductStatusName) Fixed() bool {
+	switch status {
+	case ProductStatusFirstFixed,
+		ProductStatusFixed,
+		ProductStatusRecommended:
+		return true
+	default:
+		return false
+	}
+}
+
+// Validate verifies that the product status only uses CSAF-defined status names.
+func (ps ProductStatus) Validate() error {
+	for status := range ps {
+		if !ProductStatusName(status).Valid() {
+			return fmt.Errorf("invalid product_status value %q, must be one of [%s]", status, strings.Join(ProductStatusNames(), ", "))
+		}
+	}
+	return nil
+}

--- a/pkg/csaf/product_status_test.go
+++ b/pkg/csaf/product_status_test.go
@@ -1,0 +1,79 @@
+// Copyright 2023 The OpenVEX Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package csaf
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProductStatusNames(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{
+		"first_affected",
+		"first_fixed",
+		"fixed",
+		"known_affected",
+		"known_not_affected",
+		"last_affected",
+		"recommended",
+		"under_investigation",
+	}, ProductStatusNames())
+}
+
+func TestProductStatusValidate(t *testing.T) {
+	t.Parallel()
+
+	valid := ProductStatus{
+		ProductStatusFirstAffected:      {"CSAFPID-0001"},
+		ProductStatusFirstFixed:         {"CSAFPID-0002"},
+		ProductStatusFixed:              {"CSAFPID-0003"},
+		ProductStatusKnownAffected:      {"CSAFPID-0004"},
+		ProductStatusKnownNotAffected:   {"CSAFPID-0005"},
+		ProductStatusLastAffected:       {"CSAFPID-0006"},
+		ProductStatusRecommended:        {"CSAFPID-0007"},
+		ProductStatusUnderInvestigation: {"CSAFPID-0008"},
+	}
+	require.NoError(t, valid.Validate())
+
+	invalid := ProductStatus{
+		"not_a_csaf_status": {"CSAFPID-0009"},
+	}
+	require.ErrorContains(t, invalid.Validate(), "invalid product_status value")
+}
+
+func TestProductStatusJSON(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{"last_affected":["CSAFPID-0001"],"first_affected":["CSAFPID-0002"]}`)
+	productStatus := ProductStatus{}
+
+	require.NoError(t, json.Unmarshal(data, &productStatus))
+	require.Equal(t, []string{"CSAFPID-0001"}, productStatus[ProductStatusLastAffected])
+	require.Equal(t, []string{"CSAFPID-0002"}, productStatus[ProductStatusFirstAffected])
+	require.NoError(t, productStatus.Validate())
+}
+
+func TestValidateProductStatuses(t *testing.T) {
+	t.Parallel()
+
+	doc := CSAF{
+		Vulnerabilities: []Vulnerability{
+			{
+				ProductStatus: ProductStatus{
+					ProductStatusLastAffected: {"CSAFPID-0001"},
+				},
+			},
+		},
+	}
+	require.NoError(t, doc.ValidateProductStatuses())
+
+	doc.Vulnerabilities[0].ProductStatus = ProductStatus{
+		"not_a_csaf_status": {"CSAFPID-0001"},
+	}
+	require.ErrorContains(t, doc.ValidateProductStatuses(), "vulnerabilities[0].product_status")
+}

--- a/pkg/csaf/product_status_test.go
+++ b/pkg/csaf/product_status_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testProductID1 = "CSAFPID-0001"
+
 func TestProductStatusNames(t *testing.T) {
 	t.Parallel()
 
@@ -29,7 +31,7 @@ func TestProductStatusValidate(t *testing.T) {
 	t.Parallel()
 
 	valid := ProductStatus{
-		ProductStatusFirstAffected:      {"CSAFPID-0001"},
+		ProductStatusFirstAffected:      {testProductID1},
 		ProductStatusFirstFixed:         {"CSAFPID-0002"},
 		ProductStatusFixed:              {"CSAFPID-0003"},
 		ProductStatusKnownAffected:      {"CSAFPID-0004"},
@@ -53,7 +55,7 @@ func TestProductStatusJSON(t *testing.T) {
 	productStatus := ProductStatus{}
 
 	require.NoError(t, json.Unmarshal(data, &productStatus))
-	require.Equal(t, []string{"CSAFPID-0001"}, productStatus[ProductStatusLastAffected])
+	require.Equal(t, []string{testProductID1}, productStatus[ProductStatusLastAffected])
 	require.Equal(t, []string{"CSAFPID-0002"}, productStatus[ProductStatusFirstAffected])
 	require.NoError(t, productStatus.Validate())
 }
@@ -65,7 +67,7 @@ func TestValidateProductStatuses(t *testing.T) {
 		Vulnerabilities: []Vulnerability{
 			{
 				ProductStatus: ProductStatus{
-					ProductStatusLastAffected: {"CSAFPID-0001"},
+					ProductStatusLastAffected: {testProductID1},
 				},
 			},
 		},
@@ -73,7 +75,7 @@ func TestValidateProductStatuses(t *testing.T) {
 	require.NoError(t, doc.ValidateProductStatuses())
 
 	doc.Vulnerabilities[0].ProductStatus = ProductStatus{
-		"not_a_csaf_status": {"CSAFPID-0001"},
+		"not_a_csaf_status": {testProductID1},
 	}
 	require.ErrorContains(t, doc.ValidateProductStatuses(), "vulnerabilities[0].product_status")
 }

--- a/pkg/csaf/testdata/product-statuses.json
+++ b/pkg/csaf/testdata/product-statuses.json
@@ -1,0 +1,287 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "tlp": {
+        "label": "WHITE"
+      }
+    },
+    "notes": [
+      {
+        "category": "summary",
+        "text": "Golden CSAF VEX document covering every CSAF product_status bucket supported by go-vex.",
+        "title": "Coverage summary"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "security@example.com",
+      "issuing_authority": "Example Product Security",
+      "name": "Example Vendor",
+      "namespace": "https://example.com/security"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "Golden CSAF test fixture",
+        "url": "https://example.com/security/advisories/CSAF-STATUS-GOLDEN"
+      }
+    ],
+    "title": "CSAF product_status golden fixture",
+    "tracking": {
+      "current_release_date": "2026-05-26T00:00:00Z",
+      "generator": {
+        "date": "2026-05-26T00:00:00Z",
+        "engine": {
+          "name": "go-vex-test",
+          "version": "1"
+        }
+      },
+      "id": "CSAF-STATUS-GOLDEN",
+      "initial_release_date": "2026-05-26T00:00:00Z",
+      "revision_history": [
+        {
+          "date": "2026-05-26T00:00:00Z",
+          "legacy_version": "0",
+          "number": "1",
+          "summary": "Initial golden fixture."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "notes": [
+    {
+      "category": "details",
+      "text": "Document-level note used to verify CSAF note round trips.",
+      "title": "Document note"
+    }
+  ],
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Example Vendor",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "Example Product",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "first_affected",
+                "product": {
+                  "name": "Example Product first_affected",
+                  "product_id": "CSAFPID-0001",
+                  "product_identification_helper": {
+                    "purl": "pkg:generic/example/first_affected@1.0.0"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "first_fixed",
+                "product": {
+                  "name": "Example Product first_fixed",
+                  "product_id": "CSAFPID-0002",
+                  "product_identification_helper": {
+                    "purl": "pkg:generic/example/first_fixed@1.0.0"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "fixed",
+                "product": {
+                  "name": "Example Product fixed",
+                  "product_id": "CSAFPID-0003",
+                  "product_identification_helper": {
+                    "purl": "pkg:generic/example/fixed@1.0.0"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "known_affected",
+                "product": {
+                  "name": "Example Product known_affected",
+                  "product_id": "CSAFPID-0004",
+                  "product_identification_helper": {
+                    "purl": "pkg:generic/example/known_affected@1.0.0"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "known_not_affected",
+                "product": {
+                  "name": "Example Product known_not_affected",
+                  "product_id": "CSAFPID-0005",
+                  "product_identification_helper": {
+                    "purl": "pkg:generic/example/known_not_affected@1.0.0"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "last_affected",
+                "product": {
+                  "name": "Example Product last_affected",
+                  "product_id": "CSAFPID-0006",
+                  "product_identification_helper": {
+                    "purl": "pkg:generic/example/last_affected@1.0.0"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "recommended",
+                "product": {
+                  "name": "Example Product recommended",
+                  "product_id": "CSAFPID-0007",
+                  "product_identification_helper": {
+                    "purl": "pkg:generic/example/recommended@1.0.0"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "under_investigation",
+                "product": {
+                  "name": "Example Product under_investigation",
+                  "product_id": "CSAFPID-0008",
+                  "product_identification_helper": {
+                    "cpe": "cpe:2.3:a:example:under_investigation:1.0.0:*:*:*:*:*:*:*",
+                    "purl": "pkg:generic/example/under_investigation@1.0.0"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "Example Product Component",
+          "product_id": "CSAFPID-REL-0001"
+        },
+        "product_reference": "CSAFPID-0001",
+        "relates_to_product_reference": "CSAFPID-0004"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2026-46598",
+      "ids": [
+        {
+          "system_name": "Example Tracker",
+          "text": "EXAMPLE-2026-46598"
+        }
+      ],
+      "title": "Example vulnerability covering CSAF product statuses",
+      "release_date": "2026-05-26T00:00:00Z",
+      "notes": [
+        {
+          "category": "description",
+          "text": "This fixture exercises all product_status buckets modeled by go-vex.",
+          "title": "Description"
+        }
+      ],
+      "product_status": {
+        "first_affected": [
+          "CSAFPID-0001"
+        ],
+        "first_fixed": [
+          "CSAFPID-0002"
+        ],
+        "fixed": [
+          "CSAFPID-0003"
+        ],
+        "known_affected": [
+          "CSAFPID-0004"
+        ],
+        "known_not_affected": [
+          "CSAFPID-0005"
+        ],
+        "last_affected": [
+          "CSAFPID-0006"
+        ],
+        "recommended": [
+          "CSAFPID-0007"
+        ],
+        "under_investigation": [
+          "CSAFPID-0008"
+        ]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Impact for known_not_affected",
+          "product_ids": [
+            "CSAFPID-0005"
+          ]
+        }
+      ],
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "date": "2026-05-26T00:00:00Z",
+          "details": "Update first_affected",
+          "entitlements": [
+            "public"
+          ],
+          "group_ids": [
+            "GROUP-0001"
+          ],
+          "product_ids": [
+            "CSAFPID-0001"
+          ],
+          "restart_required": {
+            "category": "none",
+            "details": "No restart required."
+          },
+          "url": "https://example.com/fixes/first_affected"
+        },
+        {
+          "category": "vendor_fix",
+          "details": "Update known_affected",
+          "product_ids": [
+            "CSAFPID-0004"
+          ]
+        },
+        {
+          "category": "vendor_fix",
+          "details": "Update last_affected",
+          "product_ids": [
+            "CSAFPID-0006"
+          ]
+        }
+      ],
+      "flags": [
+        {
+          "label": "component_not_present",
+          "date": "2026-05-26T00:00:00Z",
+          "group_ids": [
+            "GROUP-0002"
+          ],
+          "product_ids": [
+            "CSAFPID-0005"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "category": "external",
+          "summary": "Example vulnerability reference",
+          "url": "https://example.com/vulns/CVE-2026-46598"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -11,12 +11,14 @@ import (
 	"github.com/openvex/go-vex/pkg/vex"
 )
 
+const testCVE123456789 = "CVE-1234-56789"
+
 func statementList(t *testing.T) []*vex.Statement {
 	t.Helper()
 	return []*vex.Statement{
 		{
 			Vulnerability: vex.Vulnerability{
-				Name: "CVE-1234-56789",
+				Name: testCVE123456789,
 				Aliases: []vex.VulnerabilityID{
 					"GHE-1234-56789",
 				},
@@ -102,8 +104,8 @@ func TestMatch(t *testing.T) {
 		expectedLength int
 	}{
 		{name: "test", filters: []FilterFunc{}, expectedLength: 0},
-		{name: "vuln", filters: []FilterFunc{WithVulnerability(&vex.Vulnerability{Name: "CVE-1234-56789"})}, expectedLength: 1},
-		{name: "vulnAlias", filters: []FilterFunc{WithVulnerability(&vex.Vulnerability{Name: "CVE-1234-56789", Aliases: []vex.VulnerabilityID{"GHE-1234-56789"}})}, expectedLength: 1},
+		{name: "vuln", filters: []FilterFunc{WithVulnerability(&vex.Vulnerability{Name: testCVE123456789})}, expectedLength: 1},
+		{name: "vulnAlias", filters: []FilterFunc{WithVulnerability(&vex.Vulnerability{Name: testCVE123456789, Aliases: []vex.VulnerabilityID{"GHE-1234-56789"}})}, expectedLength: 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/vex/compat_test.go
+++ b/pkg/vex/compat_test.go
@@ -21,7 +21,7 @@ func TestParse001(t *testing.T) {
 		expected  *VEX
 	}{
 		"normal": {
-			"testdata/v0.0.1.json",
+			testV001Path,
 			false,
 			&VEX{
 				Metadata: Metadata{

--- a/pkg/vex/component_test.go
+++ b/pkg/vex/component_test.go
@@ -21,53 +21,53 @@ func TestComponentMatches(t *testing.T) {
 			true,
 		},
 		"misc identifier": {
-			"madeup-2023-12345",
+			testMadeupIdentifier,
 			&Component{
-				Identifiers: map[IdentifierType]string{"customIdentifier": "madeup-2023-12345"},
+				Identifiers: map[IdentifierType]string{"customIdentifier": testMadeupIdentifier},
 			},
 			true,
 		},
 		"wrong misc identifier": {
-			"madeup-2023-12345",
+			testMadeupIdentifier,
 			&Component{
 				Identifiers: map[IdentifierType]string{"customIdentifier": "another-string"},
 			},
 			false,
 		},
 		"same purl": {
-			"pkg:apk/wolfi/curl@8.1.2-r0?arch=x86_64",
+			testWolfiCurlPURL,
 			&Component{
-				Identifiers: map[IdentifierType]string{PURL: "pkg:apk/wolfi/curl@8.1.2-r0?arch=x86_64"},
+				Identifiers: map[IdentifierType]string{PURL: testWolfiCurlPURL},
 			},
 			true,
 		},
 		"globing purl": {
-			"pkg:oci/curl@sha256:47fed8868b46b060efb8699dc40e981a0c785650223e03602d8c4493fc75b68c",
+			testOCICurlDigestPURL,
 			&Component{
-				Identifiers: map[IdentifierType]string{PURL: "pkg:oci/curl"},
+				Identifiers: map[IdentifierType]string{PURL: testOCICurlPURL},
 			},
 			true,
 		},
 		"globing purl (inverse)": {
-			"pkg:oci/curl",
+			testOCICurlPURL,
 			&Component{
 				Identifiers: map[IdentifierType]string{
-					PURL: "pkg:oci/curl@sha256:47fed8868b46b060efb8699dc40e981a0c785650223e03602d8c4493fc75b68c",
+					PURL: testOCICurlDigestPURL,
 				},
 			},
 			false,
 		},
 		"hash": {
-			"77d86e9752cb933569dfa1f693ee4338e65b28b4",
+			testSHA1Digest,
 			&Component{
 				Hashes: map[Algorithm]Hash{
-					SHA1: "77d86e9752cb933569dfa1f693ee4338e65b28b4",
+					SHA1: testSHA1Digest,
 				},
 			},
 			true,
 		},
 		"wrong hash": {
-			"77d86e9752cb933569dfa1f693ee4338e65b28b4",
+			testSHA1Digest,
 			&Component{
 				Hashes: map[Algorithm]Hash{
 					SHA1: "b5cc41d90d7ccc195c4a24ceb32656942c9854ea",

--- a/pkg/vex/functions_files.go
+++ b/pkg/vex/functions_files.go
@@ -176,36 +176,40 @@ func OpenCSAF(path string, products []string) (*VEX, error) {
 	for i := range csafDoc.Vulnerabilities {
 		for status, docProducts := range csafDoc.Vulnerabilities[i].ProductStatus {
 			for _, productID := range docProducts {
-				if product, ok := productDict[productID]; ok {
-					// Check we have a valid status
-					vexStatus := StatusFromCSAF(string(status))
-					if vexStatus == "" {
-						return nil, fmt.Errorf("invalid status for product %s", productID)
-					}
-
-					stmt := Statement{
-						Vulnerability: Vulnerability{Name: VulnerabilityID(csafDoc.Vulnerabilities[i].CVE)},
-						Status:        vexStatus,
-						StatusNotes:   fmt.Sprintf("CSAF product_status: %s", status),
-						Products: []Product{
-							{
-								Component: componentFromCSAFProduct(product),
-							},
-						},
-					}
-
-					switch vexStatus {
-					case StatusAffected:
-						stmt.ActionStatement = actionStatementForProduct(csafDoc.Vulnerabilities[i], productID)
-						if stmt.ActionStatement == "" {
-							stmt.ActionStatement = NoActionStatementMsg
-						}
-					case StatusNotAffected:
-						stmt.ImpactStatement = impactStatementForProduct(csafDoc.Vulnerabilities[i], productID)
-					}
-
-					vexDoc.Statements = append(vexDoc.Statements, stmt)
+				product, ok := productDict[productID]
+				if !ok {
+					continue
 				}
+
+				// Check we have a valid status
+				vexStatus := StatusFromCSAF(status)
+				if vexStatus == "" {
+					return nil, fmt.Errorf("invalid status for product %s", productID)
+				}
+
+				stmt := Statement{
+					Vulnerability: Vulnerability{Name: VulnerabilityID(csafDoc.Vulnerabilities[i].CVE)},
+					Status:        vexStatus,
+					StatusNotes:   fmt.Sprintf("CSAF product_status: %s", status),
+					Products: []Product{
+						{
+							Component: componentFromCSAFProduct(product),
+						},
+					},
+				}
+
+				switch vexStatus {
+				case StatusAffected:
+					stmt.ActionStatement = actionStatementForProduct(&csafDoc.Vulnerabilities[i], productID)
+					if stmt.ActionStatement == "" {
+						stmt.ActionStatement = NoActionStatementMsg
+					}
+				case StatusNotAffected:
+					stmt.ImpactStatement = impactStatementForProduct(&csafDoc.Vulnerabilities[i], productID)
+				case StatusFixed, StatusUnderInvestigation:
+				}
+
+				vexDoc.Statements = append(vexDoc.Statements, stmt)
 			}
 		}
 	}
@@ -243,19 +247,19 @@ func componentFromCSAFProduct(product csaf.Product) Component {
 	return component
 }
 
-func actionStatementForProduct(vuln csaf.Vulnerability, productID string) string {
-	for _, remediation := range vuln.Remediations {
-		if productIDMatches(remediation.ProductIDs, productID) {
-			return remediation.Details
+func actionStatementForProduct(vuln *csaf.Vulnerability, productID string) string {
+	for i := range vuln.Remediations {
+		if productIDMatches(vuln.Remediations[i].ProductIDs, productID) {
+			return vuln.Remediations[i].Details
 		}
 	}
 	return ""
 }
 
-func impactStatementForProduct(vuln csaf.Vulnerability, productID string) string {
-	for _, threat := range vuln.Threats {
-		if productIDMatches(threat.ProductIDs, productID) {
-			return threat.Details
+func impactStatementForProduct(vuln *csaf.Vulnerability, productID string) string {
+	for i := range vuln.Threats {
+		if productIDMatches(vuln.Threats[i].ProductIDs, productID) {
+			return vuln.Threats[i].Details
 		}
 	}
 	return ""

--- a/pkg/vex/functions_files.go
+++ b/pkg/vex/functions_files.go
@@ -135,8 +135,11 @@ func OpenCSAF(path string, products []string) (*VEX, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening csaf doc: %w", err)
 	}
+	if err := csafDoc.ValidateProductStatuses(); err != nil {
+		return nil, fmt.Errorf("validating csaf product statuses: %w", err)
+	}
 
-	productDict := map[string]string{}
+	productDict := map[string]csaf.Product{}
 	filterDict := map[string]string{}
 	for _, pid := range products {
 		filterDict[pid] = pid
@@ -159,9 +162,7 @@ func OpenCSAF(path string, products []string) (*VEX, error) {
 			}
 		}
 
-		for _, h := range sp.IdentificationHelper {
-			productDict[sp.ID] = h
-		}
+		productDict[sp.ID] = sp
 	}
 
 	// Create the vex doc
@@ -179,42 +180,98 @@ func OpenCSAF(path string, products []string) (*VEX, error) {
 	for i := range csafDoc.Vulnerabilities {
 		for status, docProducts := range csafDoc.Vulnerabilities[i].ProductStatus {
 			for _, productID := range docProducts {
-				if _, ok := productDict[productID]; ok {
+				if product, ok := productDict[productID]; ok {
 					// Check we have a valid status
-					if StatusFromCSAF(status) == "" {
+					vexStatus := StatusFromCSAF(string(status))
+					if vexStatus == "" {
 						return nil, fmt.Errorf("invalid status for product %s", productID)
 					}
 
-					// TODO search the threats struct for justification, etc
-					just := ""
-					for _, t := range csafDoc.Vulnerabilities[i].Threats {
-						// Search the threats for a justification
-						for _, p := range t.ProductIDs {
-							if p == productID {
-								just = t.Details
-							}
-						}
-					}
-
-					v.Statements = append(v.Statements, Statement{
-						Vulnerability:   Vulnerability{Name: VulnerabilityID(csafDoc.Vulnerabilities[i].CVE)},
-						Status:          StatusFromCSAF(status),
-						Justification:   "", // Justifications are not machine readable in csaf, it seems
-						ActionStatement: just,
+					stmt := Statement{
+						Vulnerability: Vulnerability{Name: VulnerabilityID(csafDoc.Vulnerabilities[i].CVE)},
+						Status:        vexStatus,
+						StatusNotes:   fmt.Sprintf("CSAF product_status: %s", status),
 						Products: []Product{
 							{
-								Component: Component{
-									ID: productID,
-								},
+								Component: componentFromCSAFProduct(product),
 							},
 						},
-					})
+					}
+
+					switch vexStatus {
+					case StatusAffected:
+						stmt.ActionStatement = actionStatementForProduct(csafDoc.Vulnerabilities[i], productID)
+						if stmt.ActionStatement == "" {
+							stmt.ActionStatement = NoActionStatementMsg
+						}
+					case StatusNotAffected:
+						stmt.ImpactStatement = impactStatementForProduct(csafDoc.Vulnerabilities[i], productID)
+					}
+
+					v.Statements = append(v.Statements, stmt)
 				}
 			}
 		}
 	}
 
 	return v, nil
+}
+
+func componentFromCSAFProduct(product csaf.Product) Component {
+	component := Component{
+		ID: product.ID,
+	}
+
+	if purl := product.IdentificationHelper["purl"]; purl != "" {
+		component.ID = purl
+		component.Identifiers = map[IdentifierType]string{
+			PURL: purl,
+		}
+	}
+
+	if cpe := product.IdentificationHelper["cpe"]; cpe != "" {
+		if component.ID == product.ID {
+			component.ID = cpe
+		}
+		if component.Identifiers == nil {
+			component.Identifiers = map[IdentifierType]string{}
+		}
+		switch {
+		case strings.HasPrefix(cpe, "cpe:2.3:"):
+			component.Identifiers[CPE23] = cpe
+		case strings.HasPrefix(cpe, "cpe:/"):
+			component.Identifiers[CPE22] = cpe
+		}
+	}
+
+	return component
+}
+
+func actionStatementForProduct(vuln csaf.Vulnerability, productID string) string {
+	for _, remediation := range vuln.Remediations {
+		if productIDMatches(remediation.ProductIDs, productID) {
+			return remediation.Details
+		}
+	}
+	return ""
+}
+
+func impactStatementForProduct(vuln csaf.Vulnerability, productID string) string {
+	for _, threat := range vuln.Threats {
+		if productIDMatches(threat.ProductIDs, productID) {
+			return threat.Details
+		}
+	}
+	return ""
+}
+
+func productIDMatches(productIDs []string, productID string) bool {
+	for _, id := range productIDs {
+		if id == productID {
+			return true
+		}
+	}
+	return false
 }
 
 // MergeFilesWithOptions opens a list of vex documents and after parsing them

--- a/pkg/vex/functions_files.go
+++ b/pkg/vex/functions_files.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"os"
 	"strings"
-	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -165,15 +164,12 @@ func OpenCSAF(path string, products []string) (*VEX, error) {
 		productDict[sp.ID] = sp
 	}
 
-	// Create the vex doc
-	v := &VEX{
-		Metadata: Metadata{
-			ID:         csafDoc.Document.Tracking.ID,
-			Author:     "",
-			AuthorRole: "",
-			Timestamp:  &time.Time{},
-		},
-		Statements: []Statement{},
+	// Create the VEX doc with the OpenVEX defaults, then carry over CSAF metadata.
+	vexDoc := New()
+	vexDoc.ID = csafDoc.Document.Tracking.ID
+	vexDoc.Author = csafDoc.Document.Publisher.Name
+	if !csafDoc.Document.Tracking.CurrentReleaseDate.IsZero() {
+		vexDoc.Timestamp = &csafDoc.Document.Tracking.CurrentReleaseDate
 	}
 
 	// Cycle the CSAF vulns list and get those that apply
@@ -208,13 +204,13 @@ func OpenCSAF(path string, products []string) (*VEX, error) {
 						stmt.ImpactStatement = impactStatementForProduct(csafDoc.Vulnerabilities[i], productID)
 					}
 
-					v.Statements = append(v.Statements, stmt)
+					vexDoc.Statements = append(vexDoc.Statements, stmt)
 				}
 			}
 		}
 	}
 
-	return v, nil
+	return &vexDoc, nil
 }
 
 func componentFromCSAFProduct(product csaf.Product) Component {

--- a/pkg/vex/functions_files_test.go
+++ b/pkg/vex/functions_files_test.go
@@ -5,11 +5,9 @@ package vex
 
 import (
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/openvex/go-vex/pkg/csaf"
 	"github.com/stretchr/testify/require"
@@ -90,9 +88,7 @@ func TestOpenCSAF(t *testing.T) {
 func TestOpenCSAFProductStatuses(t *testing.T) {
 	t.Parallel()
 
-	docPath := writeCSAFProductStatusFixture(t)
-
-	doc, err := OpenCSAF(docPath, []string{})
+	doc, err := OpenCSAF("../csaf/testdata/product-statuses.json", []string{})
 	require.NoError(t, err)
 	require.Len(t, doc.Statements, 8)
 
@@ -155,116 +151,4 @@ func TestOpen(t *testing.T) {
 		require.NoError(t, err, m)
 		require.NotNil(t, doc, m)
 	}
-}
-
-func writeCSAFProductStatusFixture(t *testing.T) string {
-	t.Helper()
-
-	issuedAt := time.Date(2026, time.May, 26, 0, 0, 0, 0, time.UTC)
-	statuses := []csaf.ProductStatusName{
-		csaf.ProductStatusFirstAffected,
-		csaf.ProductStatusFirstFixed,
-		csaf.ProductStatusFixed,
-		csaf.ProductStatusKnownAffected,
-		csaf.ProductStatusKnownNotAffected,
-		csaf.ProductStatusLastAffected,
-		csaf.ProductStatusRecommended,
-		csaf.ProductStatusUnderInvestigation,
-	}
-
-	branches := make([]csaf.ProductBranch, 0, len(statuses))
-	productStatus := csaf.ProductStatus{}
-	remediations := []csaf.RemediationData{}
-	threats := []csaf.ThreatData{}
-
-	for i, status := range statuses {
-		productID := "CSAFPID-000" + string(rune('1'+i))
-		purl := "pkg:generic/example/" + string(status) + "@1.0.0"
-
-		productStatus[string(status)] = []string{productID}
-		branches = append(branches, csaf.ProductBranch{
-			Category: "product_version",
-			Name:     string(status),
-			Product: csaf.Product{
-				Name: "Example " + string(status),
-				ID:   productID,
-				IdentificationHelper: map[string]string{
-					"purl": purl,
-				},
-			},
-		})
-
-		if status.Affected() {
-			remediations = append(remediations, csaf.RemediationData{
-				Category:   "vendor_fix",
-				Details:    "Update " + string(status),
-				ProductIDs: []string{productID},
-			})
-		}
-		if status == csaf.ProductStatusKnownNotAffected {
-			threats = append(threats, csaf.ThreatData{
-				Category:   "impact",
-				Details:    "Impact for " + string(status),
-				ProductIDs: []string{productID},
-			})
-		}
-	}
-
-	doc := csaf.CSAF{
-		Document: csaf.DocumentMetadata{
-			Category:    "csaf_vex",
-			CSAFVersion: "2.0",
-			Title:       "CSAF product status fixture",
-			Publisher: csaf.Publisher{
-				Category:  "vendor",
-				Name:      "Example",
-				Namespace: "https://example.com",
-			},
-			Tracking: csaf.Tracking{
-				ID:                 "CSAF-PRODUCT-STATUS-FIXTURE",
-				CurrentReleaseDate: issuedAt,
-				InitialReleaseDate: issuedAt,
-				RevisionHistory: []csaf.Revision{
-					{
-						Date:    issuedAt,
-						Number:  "1",
-						Summary: "Initial version.",
-					},
-				},
-				Status:  "final",
-				Version: "1",
-			},
-		},
-		ProductTree: csaf.ProductBranch{
-			Branches: []csaf.ProductBranch{
-				{
-					Category: "vendor",
-					Name:     "Example",
-					Branches: []csaf.ProductBranch{
-						{
-							Category: "product_name",
-							Name:     "Example",
-							Branches: branches,
-						},
-					},
-				},
-			},
-		},
-		Vulnerabilities: []csaf.Vulnerability{
-			{
-				CVE:           "CVE-2026-46598",
-				ProductStatus: productStatus,
-				Remediations:  remediations,
-				Threats:       threats,
-			},
-		},
-	}
-
-	path := filepath.Join(t.TempDir(), "csaf.json")
-	fh, err := os.Create(path)
-	require.NoError(t, err)
-	require.NoError(t, doc.ToJSON(fh))
-	require.NoError(t, fh.Close())
-
-	return path
 }

--- a/pkg/vex/functions_files_test.go
+++ b/pkg/vex/functions_files_test.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openvex/go-vex/pkg/csaf"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openvex/go-vex/pkg/csaf"
 )
 
 func TestParse(t *testing.T) {
@@ -21,9 +22,9 @@ func TestParse(t *testing.T) {
 		shouldErr bool
 	}{
 		// Previous versions fail on test
-		"OpenVEX v0.0.1": {"testdata/v0.0.1.json", "", []string{}, true},
+		"OpenVEX v0.0.1": {testV001Path, "", []string{}, true},
 		// Current version
-		"OpenVEX v0.2.0": {"testdata/v0.2.0.json", "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126", []string{"CVE-2023-1255", "CVE-2023-2650", "CVE-2023-2975", "CVE-2023-3446", "CVE-2023-3817"}, false},
+		"OpenVEX v0.2.0": {"testdata/v0.2.0.json", testAlpineOCIPURL, []string{testCVE20231255, "CVE-2023-2650", "CVE-2023-2975", "CVE-2023-3446", "CVE-2023-3817"}, false},
 	} {
 		data, err := os.ReadFile(tc.path)
 		require.NoError(t, err)
@@ -58,7 +59,7 @@ func TestLoadYAML(t *testing.T) {
 }
 
 func TestLoadCSAF(t *testing.T) {
-	vexDoc, err := OpenCSAF("testdata/csaf.json", []string{})
+	vexDoc, err := OpenCSAF(testCSAFPath, []string{})
 	require.NoError(t, err)
 	require.Len(t, vexDoc.Statements, 1)
 	require.Len(t, vexDoc.Statements[0].Products, 1)
@@ -75,8 +76,8 @@ func TestOpenCSAF(t *testing.T) {
 		len int
 		id  []string
 	}{
-		{"testdata/csaf.json", 1, []string{"CSAFPID-0001"}},
-		{"testdata/csaf.json", 1, []string{"pkg:golang/github.com/go-homedir@v1.2.0"}},
+		{testCSAFPath, 1, []string{"CSAFPID-0001"}},
+		{testCSAFPath, 1, []string{"pkg:golang/github.com/go-homedir@v1.2.0"}},
 	} {
 		doc, err := OpenCSAF(tc.doc, tc.id)
 		require.NoError(t, err)
@@ -137,10 +138,10 @@ func TestOpen(t *testing.T) {
 		path      string
 		shouldErr bool
 	}{
-		"OpenVEX v0.0.1":              {"testdata/v0.0.1.json", false},
+		"OpenVEX v0.0.1":              {testV001Path, false},
 		"OpenVEX v0.0.1 (no version)": {"testdata/v0.0.1-noversion.json", false},
 		"OpenVEX v0.2.0":              {"testdata/v0.2.0.json", false},
-		"CSAF document":               {"testdata/csaf.json", false},
+		"CSAF document":               {testCSAFPath, false},
 	} {
 		doc, err := Open(tc.path)
 		if tc.shouldErr {

--- a/pkg/vex/functions_files_test.go
+++ b/pkg/vex/functions_files_test.go
@@ -5,9 +5,13 @@ package vex
 
 import (
 	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/openvex/go-vex/pkg/csaf"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,6 +85,55 @@ func TestOpenCSAF(t *testing.T) {
 	}
 }
 
+func TestOpenCSAFProductStatuses(t *testing.T) {
+	t.Parallel()
+
+	docPath := writeCSAFProductStatusFixture(t)
+
+	doc, err := OpenCSAF(docPath, []string{})
+	require.NoError(t, err)
+	require.Len(t, doc.Statements, 8)
+
+	statements := map[string]Statement{}
+	for _, stmt := range doc.Statements {
+		csafStatus := strings.TrimPrefix(stmt.StatusNotes, "CSAF product_status: ")
+		statements[csafStatus] = stmt
+	}
+
+	for _, status := range []csaf.ProductStatusName{
+		csaf.ProductStatusFirstAffected,
+		csaf.ProductStatusKnownAffected,
+		csaf.ProductStatusLastAffected,
+	} {
+		stmt := statements[string(status)]
+		require.Equal(t, StatusAffected, stmt.Status, status)
+		require.Equal(t, "Update "+string(status), stmt.ActionStatement, status)
+	}
+
+	for _, status := range []csaf.ProductStatusName{
+		csaf.ProductStatusFirstFixed,
+		csaf.ProductStatusFixed,
+		csaf.ProductStatusRecommended,
+	} {
+		stmt := statements[string(status)]
+		require.Equal(t, StatusFixed, stmt.Status, status)
+		require.Empty(t, stmt.ActionStatement, status)
+	}
+
+	notAffected := statements[string(csaf.ProductStatusKnownNotAffected)]
+	require.Equal(t, StatusNotAffected, notAffected.Status)
+	require.Equal(t, "Impact for known_not_affected", notAffected.ImpactStatement)
+	require.Empty(t, notAffected.ActionStatement)
+
+	underInvestigation := statements[string(csaf.ProductStatusUnderInvestigation)]
+	require.Equal(t, StatusUnderInvestigation, underInvestigation.Status)
+	require.Empty(t, underInvestigation.ActionStatement)
+
+	lastAffected := statements[string(csaf.ProductStatusLastAffected)]
+	require.Equal(t, "pkg:generic/example/last_affected@1.0.0", lastAffected.Products[0].ID)
+	require.Equal(t, "pkg:generic/example/last_affected@1.0.0", lastAffected.Products[0].Identifiers[PURL])
+}
+
 func TestOpen(t *testing.T) {
 	for m, tc := range map[string]struct {
 		path      string
@@ -100,4 +153,116 @@ func TestOpen(t *testing.T) {
 		require.NoError(t, err, m)
 		require.NotNil(t, doc, m)
 	}
+}
+
+func writeCSAFProductStatusFixture(t *testing.T) string {
+	t.Helper()
+
+	issuedAt := time.Date(2026, time.May, 26, 0, 0, 0, 0, time.UTC)
+	statuses := []csaf.ProductStatusName{
+		csaf.ProductStatusFirstAffected,
+		csaf.ProductStatusFirstFixed,
+		csaf.ProductStatusFixed,
+		csaf.ProductStatusKnownAffected,
+		csaf.ProductStatusKnownNotAffected,
+		csaf.ProductStatusLastAffected,
+		csaf.ProductStatusRecommended,
+		csaf.ProductStatusUnderInvestigation,
+	}
+
+	branches := make([]csaf.ProductBranch, 0, len(statuses))
+	productStatus := csaf.ProductStatus{}
+	remediations := []csaf.RemediationData{}
+	threats := []csaf.ThreatData{}
+
+	for i, status := range statuses {
+		productID := "CSAFPID-000" + string(rune('1'+i))
+		purl := "pkg:generic/example/" + string(status) + "@1.0.0"
+
+		productStatus[string(status)] = []string{productID}
+		branches = append(branches, csaf.ProductBranch{
+			Category: "product_version",
+			Name:     string(status),
+			Product: csaf.Product{
+				Name: "Example " + string(status),
+				ID:   productID,
+				IdentificationHelper: map[string]string{
+					"purl": purl,
+				},
+			},
+		})
+
+		if status.Affected() {
+			remediations = append(remediations, csaf.RemediationData{
+				Category:   "vendor_fix",
+				Details:    "Update " + string(status),
+				ProductIDs: []string{productID},
+			})
+		}
+		if status == csaf.ProductStatusKnownNotAffected {
+			threats = append(threats, csaf.ThreatData{
+				Category:   "impact",
+				Details:    "Impact for " + string(status),
+				ProductIDs: []string{productID},
+			})
+		}
+	}
+
+	doc := csaf.CSAF{
+		Document: csaf.DocumentMetadata{
+			Category:    "csaf_vex",
+			CSAFVersion: "2.0",
+			Title:       "CSAF product status fixture",
+			Publisher: csaf.Publisher{
+				Category:  "vendor",
+				Name:      "Example",
+				Namespace: "https://example.com",
+			},
+			Tracking: csaf.Tracking{
+				ID:                 "CSAF-PRODUCT-STATUS-FIXTURE",
+				CurrentReleaseDate: issuedAt,
+				InitialReleaseDate: issuedAt,
+				RevisionHistory: []csaf.Revision{
+					{
+						Date:    issuedAt,
+						Number:  "1",
+						Summary: "Initial version.",
+					},
+				},
+				Status:  "final",
+				Version: "1",
+			},
+		},
+		ProductTree: csaf.ProductBranch{
+			Branches: []csaf.ProductBranch{
+				{
+					Category: "vendor",
+					Name:     "Example",
+					Branches: []csaf.ProductBranch{
+						{
+							Category: "product_name",
+							Name:     "Example",
+							Branches: branches,
+						},
+					},
+				},
+			},
+		},
+		Vulnerabilities: []csaf.Vulnerability{
+			{
+				CVE:           "CVE-2026-46598",
+				ProductStatus: productStatus,
+				Remediations:  remediations,
+				Threats:       threats,
+			},
+		},
+	}
+
+	path := filepath.Join(t.TempDir(), "csaf.json")
+	fh, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, doc.ToJSON(fh))
+	require.NoError(t, fh.Close())
+
+	return path
 }

--- a/pkg/vex/functions_files_test.go
+++ b/pkg/vex/functions_files_test.go
@@ -66,6 +66,8 @@ func TestLoadCSAF(t *testing.T) {
 	require.Len(t, vexDoc.Statements[0].Products, 1)
 	require.Equal(t, "CVE-2009-4487", string(vexDoc.Statements[0].Vulnerability.Name))
 	require.Equal(t, StatusNotAffected, vexDoc.Statements[0].Status)
+	require.Equal(t, ContextLocator(), vexDoc.Context)
+	require.Equal(t, 1, vexDoc.Version)
 	require.Equal(t, "2022-EVD-UC-01-NA-001", vexDoc.ID)
 }
 

--- a/pkg/vex/product_test.go
+++ b/pkg/vex/product_test.go
@@ -18,19 +18,19 @@ func TestProductMatches(t *testing.T) {
 	}{
 		"identifier only": {
 			sut: &Product{
-				Component: Component{ID: "pkg:apk/alpine/libcrypto3@3.0.8-r3"},
+				Component: Component{ID: testLibcryptoPURL},
 			},
-			product:      "pkg:apk/alpine/libcrypto3@3.0.8-r3",
+			product:      testLibcryptoPURL,
 			subcomponent: "",
 			mustMach:     true,
 		},
 		"purl only": {
 			sut: &Product{
 				Component: Component{Identifiers: map[IdentifierType]string{
-					PURL: "pkg:apk/alpine/libcrypto3@3.0.8-r3",
+					PURL: testLibcryptoPURL,
 				}},
 			},
-			product:      "pkg:apk/alpine/libcrypto3@3.0.8-r3",
+			product:      testLibcryptoPURL,
 			subcomponent: "",
 			mustMach:     true,
 		},
@@ -40,54 +40,54 @@ func TestProductMatches(t *testing.T) {
 					PURL: "pkg:apk/alpine/libcrypto3",
 				}},
 			},
-			product:      "pkg:apk/alpine/libcrypto3@3.0.8-r3",
+			product:      testLibcryptoPURL,
 			subcomponent: "",
 			mustMach:     true,
 		},
 		"identifier and components in doc and statement": {
 			sut: &Product{
-				Component: Component{ID: "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126"},
+				Component: Component{ID: testAlpineOCIPURL},
 				Subcomponents: []Subcomponent{
 					{
-						Component{ID: "pkg:apk/alpine/libcrypto3@3.0.8-r3"},
+						Component{ID: testLibcryptoPURL},
 					},
 				},
 			},
-			product:      "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
-			subcomponent: "pkg:apk/alpine/libcrypto3@3.0.8-r3",
+			product:      testAlpineOCIPURL,
+			subcomponent: testLibcryptoPURL,
 			mustMach:     true,
 		},
 		"identifier and no components in query": {
 			sut: &Product{
-				Component: Component{ID: "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126"},
+				Component: Component{ID: testAlpineOCIPURL},
 				Subcomponents: []Subcomponent{
 					{
-						Component{ID: "pkg:apk/alpine/libcrypto3@3.0.8-r3"},
+						Component{ID: testLibcryptoPURL},
 					},
 				},
 			},
-			product:      "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+			product:      testAlpineOCIPURL,
 			subcomponent: "",
 			mustMach:     true,
 		},
 		"identifier and no components in document": {
 			sut: &Product{
-				Component:     Component{ID: "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126"},
+				Component:     Component{ID: testAlpineOCIPURL},
 				Subcomponents: []Subcomponent{},
 			},
-			product:      "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
-			subcomponent: "pkg:apk/alpine/libcrypto3@3.0.8-r3",
+			product:      testAlpineOCIPURL,
+			subcomponent: testLibcryptoPURL,
 			mustMach:     true,
 		},
 		"identifier + multicomponent doc": {
 			sut: &Product{
-				Component: Component{ID: "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126"},
+				Component: Component{ID: testAlpineOCIPURL},
 				Subcomponents: []Subcomponent{
-					{Component{ID: "pkg:apk/alpine/libcrypto3@3.0.8-r3"}},
+					{Component{ID: testLibcryptoPURL}},
 					{Component{ID: "pkg:apk/alpine/libssl@3.0.8-r3"}},
 				},
 			},
-			product:      "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+			product:      testAlpineOCIPURL,
 			subcomponent: "pkg:apk/alpine/libssl@3.0.8-r3",
 			mustMach:     true,
 		},

--- a/pkg/vex/status.go
+++ b/pkg/vex/status.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package vex
 
+import "github.com/openvex/go-vex/pkg/csaf"
+
 // Status describes the exploitability status of a component with respect to a
 // vulnerability.
 type Status string
@@ -51,14 +53,18 @@ func (s Status) Valid() bool {
 
 // StatusFromCSAF returns a vex status from the CSAF status
 func StatusFromCSAF(csafStatus string) Status {
-	switch csafStatus {
-	case "known_not_affected":
+	switch csaf.ProductStatusName(csafStatus) {
+	case csaf.ProductStatusKnownNotAffected:
 		return StatusNotAffected
-	case "fixed":
+	case csaf.ProductStatusFixed,
+		csaf.ProductStatusFirstFixed,
+		csaf.ProductStatusRecommended:
 		return StatusFixed
-	case "under_investigation":
+	case csaf.ProductStatusUnderInvestigation:
 		return StatusUnderInvestigation
-	case "known_affected":
+	case csaf.ProductStatusKnownAffected,
+		csaf.ProductStatusFirstAffected,
+		csaf.ProductStatusLastAffected:
 		return StatusAffected
 	default:
 		return ""

--- a/pkg/vex/test_constants_test.go
+++ b/pkg/vex/test_constants_test.go
@@ -1,0 +1,20 @@
+// Copyright 2026 The OpenVEX Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package vex
+
+const (
+	testAlpineOCIPURL        = "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126"
+	testCSAFPath             = "testdata/csaf.json"
+	testCVE2014              = "CVE-2014-123456"
+	testCVE20231255          = "CVE-2023-1255"
+	testDebPkgPURL           = "pkg:deb/pkg@1.0"
+	testLibcryptoPURL        = "pkg:apk/alpine/libcrypto3@3.0.8-r3"
+	testMadeupIdentifier     = "madeup-2023-12345"
+	testOCICurlDigestPURL    = "pkg:oci/curl@sha256:47fed8868b46b060efb8699dc40e981a0c785650223e03602d8c4493fc75b68c"
+	testOCICurlPURL          = "pkg:oci/curl"
+	testSHA1Digest           = "77d86e9752cb933569dfa1f693ee4338e65b28b4"
+	testV001Path             = "testdata/v0.0.1.json"
+	testWolfiCurlPURL        = "pkg:apk/wolfi/curl@8.1.2-r0?arch=x86_64"
+	testWolfiCurlVersionPURL = "pkg:apk/wolfi/curl@8.1.2-r0"
+)

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -25,15 +25,15 @@ func TestEffectiveStatement(t *testing.T) {
 			vexDoc: &VEX{
 				Statements: []Statement{
 					{
-						Vulnerability: Vulnerability{Name: "CVE-2014-123456"},
+						Vulnerability: Vulnerability{Name: testCVE2014},
 						Timestamp:     &date1,
-						Products:      []Product{{Component: Component{ID: "pkg:deb/pkg@1.0"}}},
+						Products:      []Product{{Component: Component{ID: testDebPkgPURL}}},
 						Status:        StatusNotAffected,
 					},
 				},
 			},
-			vulnID:         "CVE-2014-123456",
-			product:        "pkg:deb/pkg@1.0",
+			vulnID:         testCVE2014,
+			product:        testDebPkgPURL,
 			shouldNil:      false,
 			expectedDate:   &date1,
 			expectedStatus: StatusNotAffected,
@@ -42,21 +42,21 @@ func TestEffectiveStatement(t *testing.T) {
 			vexDoc: &VEX{
 				Statements: []Statement{
 					{
-						Vulnerability: Vulnerability{Name: "CVE-2014-123456"},
+						Vulnerability: Vulnerability{Name: testCVE2014},
 						Timestamp:     &date1,
-						Products:      []Product{{Component: Component{ID: "pkg:deb/pkg@1.0"}}},
+						Products:      []Product{{Component: Component{ID: testDebPkgPURL}}},
 						Status:        StatusUnderInvestigation,
 					},
 					{
-						Vulnerability: Vulnerability{Name: "CVE-2014-123456"},
+						Vulnerability: Vulnerability{Name: testCVE2014},
 						Timestamp:     &date2,
-						Products:      []Product{{Component: Component{ID: "pkg:deb/pkg@1.0"}}},
+						Products:      []Product{{Component: Component{ID: testDebPkgPURL}}},
 						Status:        StatusNotAffected,
 					},
 				},
 			},
-			vulnID:         "CVE-2014-123456",
-			product:        "pkg:deb/pkg@1.0",
+			vulnID:         testCVE2014,
+			product:        testDebPkgPURL,
 			shouldNil:      false,
 			expectedDate:   &date2,
 			expectedStatus: StatusNotAffected,
@@ -65,21 +65,21 @@ func TestEffectiveStatement(t *testing.T) {
 			vexDoc: &VEX{
 				Statements: []Statement{
 					{
-						Vulnerability: Vulnerability{Name: "CVE-2014-123456"},
+						Vulnerability: Vulnerability{Name: testCVE2014},
 						Timestamp:     &date1,
-						Products:      []Product{{Component: Component{ID: "pkg:deb/pkg@1.0"}}},
+						Products:      []Product{{Component: Component{ID: testDebPkgPURL}}},
 						Status:        StatusUnderInvestigation,
 					},
 					{
-						Vulnerability: Vulnerability{Name: "CVE-2014-123456"},
+						Vulnerability: Vulnerability{Name: testCVE2014},
 						Timestamp:     &date2,
 						Products:      []Product{{Component: Component{ID: "pkg:deb/pkg@2.0"}}},
 						Status:        StatusNotAffected,
 					},
 				},
 			},
-			vulnID:         "CVE-2014-123456",
-			product:        "pkg:deb/pkg@1.0",
+			vulnID:         testCVE2014,
+			product:        testDebPkgPURL,
 			shouldNil:      false,
 			expectedDate:   &date1,
 			expectedStatus: StatusUnderInvestigation,
@@ -89,15 +89,15 @@ func TestEffectiveStatement(t *testing.T) {
 				Statements: []Statement{
 					{
 						Vulnerability: Vulnerability{
-							Name:    "CVE-2014-123456",
+							Name:    testCVE2014,
 							Aliases: []VulnerabilityID{"ghsa-92xj-mqp7-vmcj"},
 						},
 						Timestamp: &date1,
-						Products:  []Product{{Component: Component{ID: "pkg:deb/pkg@1.0"}}},
+						Products:  []Product{{Component: Component{ID: testDebPkgPURL}}},
 						Status:    StatusUnderInvestigation,
 					},
 					{
-						Vulnerability: Vulnerability{ID: "CVE-2014-123456"},
+						Vulnerability: Vulnerability{ID: testCVE2014},
 						Timestamp:     &date2,
 						Products:      []Product{{Component: Component{ID: "pkg:deb/pkg@2.0"}}},
 						Status:        StatusNotAffected,
@@ -105,7 +105,7 @@ func TestEffectiveStatement(t *testing.T) {
 				},
 			},
 			vulnID:         "ghsa-92xj-mqp7-vmcj",
-			product:        "pkg:deb/pkg@1.0",
+			product:        testDebPkgPURL,
 			shouldNil:      false,
 			expectedDate:   &date1,
 			expectedStatus: StatusUnderInvestigation,
@@ -287,26 +287,26 @@ func TestPurlMatches(t *testing.T) {
 		p2        string
 		mustMatch bool
 	}{
-		"same purl":         {"pkg:apk/wolfi/curl@8.1.2-r0?arch=x86_64", "pkg:apk/wolfi/curl@8.1.2-r0?arch=x86_64", true},
-		"different type":    {"pkg:apk/wolfi/curl@8.1.2-r0?arch=x86_64", "pkg:rpm/wolfi/curl@8.1.2-r0?arch=x86_64", false},
-		"different ns":      {"pkg:apk/wolfi/curl@8.1.2-r0?arch=x86_64", "pkg:apk/alpine/curl@8.1.2-r0?arch=x86_64", false},
-		"different package": {"pkg:apk/wolfi/curl@8.1.2-r0?arch=x86_64", "pkg:apk/wolfi/bash@8.1.2-r0?arch=x86_64", false},
-		"different version": {"pkg:apk/wolfi/curl@8.1.2-r0?arch=x86_64", "pkg:apk/wolfi/bash@8.1.3-r0?arch=x86_64", false},
-		"p1 no qualifiers":  {"pkg:apk/wolfi/curl@8.1.2-r0", "pkg:apk/wolfi/curl@8.1.2-r0?arch=x86_64", true},
-		"p2 no qualifiers":  {"pkg:apk/wolfi/curl@8.1.2-r0?arch=x86_64", "pkg:apk/wolfi/curl@8.1.2-r0", false},
+		"same purl":         {testWolfiCurlPURL, testWolfiCurlPURL, true},
+		"different type":    {testWolfiCurlPURL, "pkg:rpm/wolfi/curl@8.1.2-r0?arch=x86_64", false},
+		"different ns":      {testWolfiCurlPURL, "pkg:apk/alpine/curl@8.1.2-r0?arch=x86_64", false},
+		"different package": {testWolfiCurlPURL, "pkg:apk/wolfi/bash@8.1.2-r0?arch=x86_64", false},
+		"different version": {testWolfiCurlPURL, "pkg:apk/wolfi/bash@8.1.3-r0?arch=x86_64", false},
+		"p1 no qualifiers":  {testWolfiCurlVersionPURL, testWolfiCurlPURL, true},
+		"p2 no qualifiers":  {testWolfiCurlPURL, testWolfiCurlVersionPURL, false},
 		"versionless": {
-			"pkg:oci/curl",
-			"pkg:oci/curl@sha256:47fed8868b46b060efb8699dc40e981a0c785650223e03602d8c4493fc75b68c",
+			testOCICurlPURL,
+			testOCICurlDigestPURL,
 			true,
 		},
 		"different qualifier": {
-			"pkg:oci/curl@sha256:47fed8868b46b060efb8699dc40e981a0c785650223e03602d8c4493fc75b68c?arch=amd64&os=linux",
-			"pkg:oci/curl@sha256:47fed8868b46b060efb8699dc40e981a0c785650223e03602d8c4493fc75b68c?arch=arm64&os=linux",
+			testOCICurlDigestPURL + "?arch=amd64&os=linux",
+			testOCICurlDigestPURL + "?arch=arm64&os=linux",
 			false,
 		},
 		"p2 more qualifiers": {
-			"pkg:apk/wolfi/curl@8.1.2-r0?arch=x86_64",
-			"pkg:apk/wolfi/curl@8.1.2-r0?arch=x86_64&os=linux",
+			testWolfiCurlPURL,
+			testWolfiCurlPURL + "&os=linux",
 			true,
 		},
 	} {
@@ -329,22 +329,22 @@ func TestDocumentMatches(t *testing.T) {
 				Metadata: Metadata{Timestamp: &now},
 				Statements: []Statement{
 					{
-						Vulnerability: Vulnerability{ID: "CVE-2023-1255"},
+						Vulnerability: Vulnerability{ID: testCVE20231255},
 						Products: []Product{
 							{
 								Component: Component{
-									ID: "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+									ID: testAlpineOCIPURL,
 								},
 								Subcomponents: []Subcomponent{
-									// {Component: Component{ID: "pkg:apk/alpine/libcrypto3@3.0.8-r3"}},
+									// {Component: Component{ID: testLibcryptoPURL}},
 								},
 							},
 						},
 					},
 				},
 			},
-			product:       "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
-			vulnerability: "CVE-2023-1255",
+			product:       testAlpineOCIPURL,
+			vulnerability: testCVE20231255,
 			mustMach:      true,
 			numMatches:    1,
 		},


### PR DESCRIPTION
- **Expand CSAF schema product status support**
  Add schema-defined CSAF product_status constants, validation, and OpenVEX conversion mapping for first_affected, first_fixed, last_affected, recommended, and related statuses. This expands support for the CSAF schema while preserving the OpenVEX status model.
  

- **Preserve CSAF fields during round trip**
  Preserve additional modeled CSAF fields when parsing and writing CSAF documents, and initialize converted OpenVEX documents with valid metadata so CSAF-derived output can be reopened.
  

- **Add CSAF product status golden fixture**
  Add a CSAF golden document that exercises the expanded schema support, including all supported product_status buckets and newly modeled metadata fields. Use the fixture for CSAF JSON round-trip verification and CSAF-to-OpenVEX status conversion tests.
  