### PR TITLE
vex: guard nil document timestamp in StatementsByVulnerability

### DIFF
--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -415,7 +415,11 @@ func (vexDoc *VEX) StatementsByVulnerability(id string) []Statement {
 			ret = append(ret, vexDoc.Statements[i])
 		}
 	}
-	SortStatements(ret, *vexDoc.Timestamp)
+	var t time.Time
+	if vexDoc.Timestamp != nil {
+		t = *vexDoc.Timestamp
+	}
+	SortStatements(ret, t)
 	return ret
 }
 

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -450,3 +450,20 @@ func TestExtractStatements(t *testing.T) {
 		})
 	}
 }
+
+func TestStatementsByVulnerabilityNilTimestamp(t *testing.T) {
+	// A document that omits the top-level timestamp decodes with a nil
+	// Timestamp. StatementsByVulnerability must not dereference it.
+	data := []byte(`{"@context":"https://openvex.dev/ns/v0.2.0","@id":"https://example.com/vex/test","author":"test","version":1,"statements":[{"vulnerability":{"name":"CVE-2024-9999"},"products":[{"@id":"pkg:golang/example.com/x@1.0"}],"status":"not_affected","justification":"vulnerable_code_not_present"}]}`)
+
+	doc, err := Parse(data)
+	require.NoError(t, err)
+	require.Nil(t, doc.Timestamp)
+
+	var statements []Statement
+	require.NotPanics(t, func() {
+		statements = doc.StatementsByVulnerability("CVE-2024-9999")
+	})
+	require.Len(t, statements, 1)
+	require.True(t, statements[0].Vulnerability.Matches("CVE-2024-9999"))
+}


### PR DESCRIPTION
`StatementsByVulnerability` calls `SortStatements(ret, *vexDoc.Timestamp)`, which dereferences `Timestamp` (a `*time.Time`). `Metadata.Timestamp` has no `omitempty` and is not required by `Parse`/`Load`/`OpenJSON`, so a VEX document that omits the top-level `timestamp` decodes with `Timestamp == nil` and this call panics with a nil-pointer dereference. It fires even when the result set is empty, since the argument is evaluated before `SortStatements` runs.

The sibling query methods already guard this: `EffectiveStatement`, `Matches`, and `CanonicalHash` all pass a zero `time.Time` when `Timestamp` is nil. #196 added that exact guard to `CanonicalHash` for the same `*Timestamp` pattern, but this twin call was missed. This applies the same guard here.

I added a test that parses a document with no `timestamp` and calls `StatementsByVulnerability`: it panics without the guard and passes with it.