### PR TITLE
Bump linter to 2.13 and fix nits

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -54,4 +54,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.11
+          version: v2.13

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,7 +61,7 @@ linters:
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan
@@ -113,6 +113,9 @@ linters:
   settings:
     gocyclo:
       min-complexity: 35
+    goconst:
+      # Repeated literals in tests are fixtures, not magic values.
+      ignore-tests: true
     godox:
       keywords:
         - BUG

--- a/pkg/vex/functions_documents.go
+++ b/pkg/vex/functions_documents.go
@@ -131,7 +131,7 @@ func SortDocuments(docs []*VEX) []*VEX {
 		if docs[i].Timestamp == nil {
 			return false
 		}
-		return docs[i].Timestamp.Before(*(docs[j].Timestamp))
+		return docs[i].Timestamp.Before(*docs[j].Timestamp)
 	})
 	return docs
 }


### PR DESCRIPTION
This pull request includes several updates to linting configuration and a minor code fix. The main focus is on updating linter versions, adjusting linter settings, and making a small correction in the document sorting function.

**Linting configuration updates:**

* Updated the `golangci-lint` GitHub Action version from `v2.11` to `v2.13` in `.github/workflows/verify.yaml` to ensure compatibility with newer linting rules and bug fixes.
* Changed the linter name from `gomodguard` to `gomodguard_v2` in `.golangci.yml` to use the latest version of this linter.
* Added a configuration to the `goconst` linter in `.golangci.yml` to ignore repeated literals in tests, treating them as fixtures rather than magic values.

**Code fix:**

* Fixed a minor typo in the `SortDocuments` function in `pkg/vex/functions_documents.go` by correcting the variable dereference when comparing timestamps.