### PR TITLE
Push the compliance attestations to the GitHub store

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -18,7 +18,9 @@ jobs:
       id-token: write # needed for keyless signing
       contents: read
       actions: read # needed to download the SLSA source provenance
-    uses: carabiner-labs/actions/.github/workflows/osps-compliance.yaml@b537804c4c39fddd274bdb1f27d0c3dbf5aeac28 # main
+      attestations: write # needed to push the attestations to the GitHub store
+    uses: carabiner-labs/actions/.github/workflows/osps-compliance.yaml@f00eee36c5ab0f7b27169e4d21330600948046a8 # main
     with:
       branch: main
       slsa-source-workflow: SLSA Source
+      push-attestations: true


### PR DESCRIPTION
This commit enables pushing all the compliance attestations to the GitHub attestations store